### PR TITLE
Align players, wallets, and ledger with master spec

### DIFF
--- a/src/main/java/dev/mincore/MinCoreMod.java
+++ b/src/main/java/dev/mincore/MinCoreMod.java
@@ -72,7 +72,8 @@ public final class MinCoreMod implements ModInitializer {
           var p = handler.player;
           UUID uuid = p.getUuid();
           String name = p.getGameProfile().getName();
-          services.players().ensureAccount(uuid, name);
+          long now = java.time.Instant.now().getEpochSecond();
+          services.players().upsertSeen(uuid, name, now);
         });
 
     // 7) Admin commands (db diag + ledger peek)

--- a/src/main/java/dev/mincore/api/events/CoreEvents.java
+++ b/src/main/java/dev/mincore/api/events/CoreEvents.java
@@ -38,30 +38,35 @@ public interface CoreEvents {
    * Emitted when a player's balance changes.
    *
    * @param player player UUID
-   * @param oldUnits previous balance (units) or {@code -1} if unknown
-   * @param newUnits new balance (units) or {@code -1} if unknown
-   * @param reason free-form reason
-   * @param seq per-player monotonic sequence
+   * @param seq per-player monotonic sequence number
+   * @param oldUnits previous balance (units)
+   * @param newUnits new balance (units)
+   * @param reason normalized reason string
    * @param version event schema version
    */
   record BalanceChangedEvent(
-      UUID player, long oldUnits, long newUnits, String reason, long seq, int version) {}
+      UUID player, long seq, long oldUnits, long newUnits, String reason, int version) {}
 
   /**
    * Emitted when a player row is first created.
    *
    * @param player player UUID
-   * @param seq per-player monotonic sequence
+   * @param seq per-player monotonic sequence number
+   * @param name registered username
    * @param version event schema version
    */
-  record PlayerRegisteredEvent(UUID player, long seq, int version) {}
+  record PlayerRegisteredEvent(UUID player, long seq, String name, int version) {}
 
   /**
    * Emitted when a player's 'seen' timestamp is updated.
    *
    * @param player player UUID
-   * @param seq per-player monotonic sequence
+   * @param seq per-player monotonic sequence number
+   * @param oldName previous username
+   * @param newName new username
+   * @param seenAtS new seen timestamp (epoch seconds, UTC)
    * @param version event schema version
    */
-  record PlayerSeenUpdatedEvent(UUID player, long seq, int version) {}
+  record PlayerSeenUpdatedEvent(
+      UUID player, long seq, String oldName, String newName, long seenAtS, int version) {}
 }

--- a/src/main/java/dev/mincore/core/LedgerImpl.java
+++ b/src/main/java/dev/mincore/core/LedgerImpl.java
@@ -150,7 +150,7 @@ public final class LedgerImpl implements Ledger, AutoCloseable {
                       e.reason(),
                       true,
                       null,
-                      0L,
+                      e.seq(),
                       null,
                       null,
                       e.oldUnits(),

--- a/src/main/java/dev/mincore/core/Migrations.java
+++ b/src/main/java/dev/mincore/core/Migrations.java
@@ -7,148 +7,121 @@ import java.sql.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Idempotent schema migrations for MinCore.
- *
- * <p>This class creates all core tables if they do not already exist:
- *
- * <ul>
- *   <li>{@code players} — player directory + wallet balance
- *   <li>{@code player_event_seq} — per-player monotonic sequence (for event ordering)
- *   <li>{@code player_events} — append-only player balance deltas (auditable history)
- *   <li>{@code idempotency} — exact-once guard for idempotent operations
- *   <li>{@code player_attributes} — per-player JSON attributes (key/value)
- *   <li>{@code core_ledger} — unified ledger (core + add-ons)
- * </ul>
- *
- * <h2>Design</h2>
- *
- * <ul>
- *   <li>All statements are {@code CREATE TABLE IF NOT EXISTS} to avoid duplicate errors.
- *   <li>No {@code ALTER TABLE ADD CONSTRAINT} is issued on repeated boots (prevents duplicate-check
- *       errors).
- *   <li>Tables are InnoDB with utf8mb4 and {@code ROW_FORMAT=DYNAMIC} for JSON-ish payloads.
- * </ul>
- */
+/** Idempotent schema migrations for MinCore core tables. */
 public final class Migrations {
   private static final Logger LOG = LoggerFactory.getLogger("mincore");
 
   private Migrations() {}
 
   /**
-   * Applies idempotent DDL. Any single-statement failure is logged and the migrator proceeds; a
-   * hard connection failure will throw.
-   *
-   * @param services running services (for DB connection)
+   * Applies idempotent DDL. Each statement is executed independently; failures are logged and the
+   * migrator proceeds with remaining statements.
    */
   public static void apply(Services services) {
-    final String[] DDL =
-        new String[] {
-          // --- players: directory + wallet
-          """
-        CREATE TABLE IF NOT EXISTS players (
-          uuid            BINARY(16)      NOT NULL,
-          name            VARCHAR(32)     NOT NULL,
-          balance_units   BIGINT UNSIGNED NOT NULL DEFAULT 0,
-          created_at_s    BIGINT UNSIGNED NOT NULL,
-          updated_at_s    BIGINT UNSIGNED NOT NULL,
-          seen_at_s       BIGINT UNSIGNED NULL,
-          CONSTRAINT chk_balance_nonneg CHECK (balance_units >= 0),
-          PRIMARY KEY (uuid),
-          KEY idx_name (name),
-          KEY idx_seen (seen_at_s)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC
-        """,
+    final String[] ddl = {
+      // Schema version bookkeeping
+      """
+      CREATE TABLE IF NOT EXISTS core_schema_version (
+        version       INT              NOT NULL,
+        applied_at_s  BIGINT UNSIGNED  NOT NULL,
+        PRIMARY KEY (version)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC
+      """,
 
-          // --- per-player sequence; used with LAST_INSERT_ID trick in wallet ops
-          """
-        CREATE TABLE IF NOT EXISTS player_event_seq (
-          uuid BINARY(16) NOT NULL,
-          seq  BIGINT UNSIGNED NOT NULL,
-          PRIMARY KEY (uuid)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC
-        """,
+      // Player directory + wallet balance
+      """
+      CREATE TABLE IF NOT EXISTS players (
+        uuid            BINARY(16)      NOT NULL,
+        name            VARCHAR(32)     NOT NULL,
+        name_lower      VARCHAR(32) GENERATED ALWAYS AS (LOWER(name)) STORED,
+        balance_units   BIGINT          NOT NULL DEFAULT 0,
+        created_at_s    BIGINT UNSIGNED NOT NULL,
+        updated_at_s    BIGINT UNSIGNED NOT NULL,
+        seen_at_s       BIGINT UNSIGNED NULL,
+        CONSTRAINT chk_players_balance_nonneg CHECK (balance_units >= 0),
+        PRIMARY KEY (uuid),
+        KEY idx_players_name_lower (name_lower),
+        KEY idx_players_seen (seen_at_s)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC
+      """,
 
-          // --- append-only balance deltas for auditability
-          """
-        CREATE TABLE IF NOT EXISTS player_events (
-          uuid          BINARY(16)      NOT NULL,
-          seq           BIGINT UNSIGNED NOT NULL,
-          version       INT             NOT NULL,
-          delta_units   BIGINT          NOT NULL,
-          reason        VARCHAR(64)     NOT NULL,
-          created_at_s  BIGINT UNSIGNED NOT NULL,
-          PRIMARY KEY (uuid, seq),
-          KEY idx_created (created_at_s)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC
-        """,
+      // Per-player monotonic sequence (wallet + player events)
+      """
+      CREATE TABLE IF NOT EXISTS player_event_seq (
+        uuid BINARY(16) NOT NULL,
+        seq  BIGINT UNSIGNED NOT NULL,
+        PRIMARY KEY (uuid)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC
+      """,
 
-          // --- idempotency: (scope, key_hash) exact-once guard
-          """
-        CREATE TABLE IF NOT EXISTS idempotency (
-          scope         VARCHAR(64)     NOT NULL,
-          key_hash      BINARY(32)      NOT NULL,
-          payload_hash  BINARY(32)      NULL,
-          applied_at_s  BIGINT UNSIGNED NOT NULL,
-          result_code   VARCHAR(32)     NULL,
-          PRIMARY KEY (scope, key_hash),
-          KEY idx_applied (applied_at_s)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC
-        """,
+      // Idempotency guard
+      """
+      CREATE TABLE IF NOT EXISTS core_requests (
+        scope         VARCHAR(64)     NOT NULL,
+        key_hash      BINARY(32)      NOT NULL,
+        payload_hash  BINARY(32)      NOT NULL,
+        ok            TINYINT(1)      NOT NULL DEFAULT 0,
+        created_at_s  BIGINT UNSIGNED NOT NULL,
+        expires_at_s  BIGINT UNSIGNED NOT NULL,
+        PRIMARY KEY (scope, key_hash),
+        KEY idx_core_requests_expires (expires_at_s)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC
+      """,
 
-          // --- per-player JSON attributes (extensibility surface)
-          """
-        CREATE TABLE IF NOT EXISTS player_attributes (
-          owner_uuid    BINARY(16)      NOT NULL,
-          attr_key      VARCHAR(64)     NOT NULL,
-          value_json    MEDIUMTEXT      NOT NULL,
-          created_at_s  BIGINT UNSIGNED NOT NULL,
-          updated_at_s  BIGINT UNSIGNED NOT NULL,
-          PRIMARY KEY (owner_uuid, attr_key),
-          KEY idx_updated (updated_at_s)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC
-        """,
+      // Per-player JSON attributes
+      """
+      CREATE TABLE IF NOT EXISTS player_attributes (
+        owner_uuid    BINARY(16)      NOT NULL,
+        attr_key      VARCHAR(64)     NOT NULL,
+        value_json    MEDIUMTEXT      NOT NULL,
+        created_at_s  BIGINT UNSIGNED NOT NULL,
+        updated_at_s  BIGINT UNSIGNED NOT NULL,
+        CONSTRAINT chk_player_attr_json CHECK (JSON_VALID(value_json)),
+        CONSTRAINT chk_player_attr_size CHECK (CHAR_LENGTH(value_json) <= 8192),
+        PRIMARY KEY (owner_uuid, attr_key),
+        KEY idx_player_attr_updated (updated_at_s)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC
+      """,
 
-          // --- unified ledger (core + add-ons)
-          """
-        CREATE TABLE IF NOT EXISTS core_ledger (
-          id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-          ts_s            BIGINT UNSIGNED NOT NULL,
-          addon_id        VARCHAR(64)     NOT NULL,
-          op              VARCHAR(32)     NOT NULL,
-          from_uuid       BINARY(16)      NULL,
-          to_uuid         BINARY(16)      NULL,
-          amount          BIGINT          NOT NULL,
-          reason          VARCHAR(64)     NOT NULL,
-          ok              TINYINT(1)      NOT NULL,
-          code            VARCHAR(32)     NULL,
-          seq             BIGINT UNSIGNED NOT NULL DEFAULT 0,
-          idem_scope      VARCHAR(64)     NULL,
-          idem_key_hash   BINARY(32)      NULL,
-          old_units       BIGINT UNSIGNED NULL,
-          new_units       BIGINT UNSIGNED NULL,
-          server_node     VARCHAR(64)     NULL,
-          extra_json      MEDIUMTEXT      NULL,
-          PRIMARY KEY (id),
-          KEY idx_ts           (ts_s),
-          KEY idx_addon        (addon_id),
-          KEY idx_op           (op),
-          KEY idx_from         (from_uuid),
-          KEY idx_to           (to_uuid),
-          KEY idx_reason       (reason),
-          KEY idx_seq          (seq),
-          KEY idx_idem_scope   (idem_scope)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC
-        """
-        };
+      // Unified ledger
+      """
+      CREATE TABLE IF NOT EXISTS core_ledger (
+        id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        ts_s            BIGINT UNSIGNED NOT NULL,
+        addon_id        VARCHAR(64)     NOT NULL,
+        op              VARCHAR(32)     NOT NULL,
+        from_uuid       BINARY(16)      NULL,
+        to_uuid         BINARY(16)      NULL,
+        amount          BIGINT          NOT NULL,
+        reason          VARCHAR(64)     NOT NULL,
+        ok              TINYINT(1)      NOT NULL,
+        code            VARCHAR(32)     NULL,
+        seq             BIGINT UNSIGNED NOT NULL DEFAULT 0,
+        idem_scope      VARCHAR(64)     NULL,
+        idem_key_hash   BINARY(32)      NULL,
+        old_units       BIGINT          NULL,
+        new_units       BIGINT          NULL,
+        server_node     VARCHAR(64)     NULL,
+        extra_json      MEDIUMTEXT      NULL,
+        PRIMARY KEY (id),
+        KEY idx_core_ledger_ts (ts_s),
+        KEY idx_core_ledger_addon (addon_id),
+        KEY idx_core_ledger_op (op),
+        KEY idx_core_ledger_from (from_uuid),
+        KEY idx_core_ledger_to (to_uuid),
+        KEY idx_core_ledger_reason (reason),
+        KEY idx_core_ledger_seq (seq),
+        KEY idx_core_ledger_idem_scope (idem_scope)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC
+      """
+    };
 
     try (Connection c = services.database().borrowConnection();
         Statement st = c.createStatement()) {
-      for (String sql : DDL) {
+      for (String sql : ddl) {
         try {
           st.execute(sql);
         } catch (SQLException e) {
-          // Non-fatal: log and continue with next statement.
           LOG.warn(
               "(mincore) migration statement failed; continuing. cause={} sql=\n{}",
               e.getMessage(),
@@ -156,7 +129,6 @@ public final class Migrations {
         }
       }
     } catch (SQLException e) {
-      // Hard failure to borrow/execute — bubble up to fail fast at boot.
       throw new RuntimeException("Migration failed", e);
     }
   }

--- a/src/main/java/dev/mincore/core/PlayersImpl.java
+++ b/src/main/java/dev/mincore/core/PlayersImpl.java
@@ -2,8 +2,17 @@
 package dev.mincore.core;
 
 import dev.mincore.api.Players;
-import java.sql.*;
+import dev.mincore.api.events.CoreEvents;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -11,13 +20,11 @@ import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * MariaDB-backed implementation of {@link Players}.
- *
- * <p>Maintains a generated lowercase name column for faster case-insensitive name lookups.
- */
+/** MariaDB-backed implementation of {@link Players}. */
 public final class PlayersImpl implements Players {
   private static final Logger LOG = LoggerFactory.getLogger("mincore");
+  private static final int EVENT_VERSION = 1;
+
   private final DataSource ds;
   private final EventBus events;
 
@@ -25,212 +32,265 @@ public final class PlayersImpl implements Players {
    * Creates a new instance.
    *
    * @param ds shared datasource
-   * @param events event bus
+   * @param events event bus for player lifecycle notifications
    */
-  public PlayersImpl(javax.sql.DataSource ds, EventBus events) {
+  public PlayersImpl(DataSource ds, EventBus events) {
     this.ds = ds;
     this.events = events;
   }
 
   @Override
-  public void ensureAccount(UUID uuid, String name) {
+  public Optional<PlayerRef> byUuid(UUID uuid) {
+    if (uuid == null) return Optional.empty();
     String sql =
-        "INSERT INTO players(uuid,name,created_at_s,updated_at_s,seen_at_s) VALUES(UNHEX(REPLACE(?, \"-\", \"\")), ?, ?, ?, ?) "
-            + "ON DUPLICATE KEY UPDATE name=VALUES(name), seen_at_s=VALUES(seen_at_s), updated_at_s=VALUES(updated_at_s)";
-    long now = Instant.now().getEpochSecond();
+        "SELECT uuid,name,created_at_s,updated_at_s,seen_at_s,balance_units FROM players WHERE uuid=?";
     try (Connection c = ds.getConnection();
         PreparedStatement ps = c.prepareStatement(sql)) {
-      c.setAutoCommit(true);
-      ps.setString(1, uuid.toString());
+      ps.setBytes(1, uuidToBytes(uuid));
+      try (ResultSet rs = ps.executeQuery()) {
+        if (rs.next()) {
+          return Optional.of(mapPlayer(rs));
+        }
+      }
+    } catch (SQLException e) {
+      LOG.warn("(mincore) players.byUuid failed", e);
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<PlayerRef> byName(String name) {
+    if (name == null || name.isBlank()) return Optional.empty();
+    String sql =
+        "SELECT uuid,name,created_at_s,updated_at_s,seen_at_s,balance_units FROM players WHERE name_lower=?";
+    try (Connection c = ds.getConnection();
+        PreparedStatement ps = c.prepareStatement(sql)) {
+      ps.setString(1, normalizeNameKey(name));
+      try (ResultSet rs = ps.executeQuery()) {
+        if (rs.next()) {
+          return Optional.of(mapPlayer(rs));
+        }
+      }
+    } catch (SQLException e) {
+      LOG.warn("(mincore) players.byName failed", e);
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public List<PlayerRef> byNameAll(String name) {
+    List<PlayerRef> out = new ArrayList<>();
+    if (name == null || name.isBlank()) {
+      return List.of();
+    }
+    String sql =
+        "SELECT uuid,name,created_at_s,updated_at_s,seen_at_s,balance_units FROM players WHERE name_lower=? ORDER BY uuid";
+    try (Connection c = ds.getConnection();
+        PreparedStatement ps = c.prepareStatement(sql)) {
+      ps.setString(1, normalizeNameKey(name));
+      try (ResultSet rs = ps.executeQuery()) {
+        while (rs.next()) {
+          out.add(mapPlayer(rs));
+        }
+      }
+    } catch (SQLException e) {
+      LOG.warn("(mincore) players.byNameAll failed", e);
+    }
+    return List.copyOf(out);
+  }
+
+  @Override
+  public void upsertSeen(UUID uuid, String name, long seenAtS) {
+    if (uuid == null) return;
+    String cleanName = sanitizeName(name);
+    Long seen = seenAtS > 0 ? seenAtS : null;
+    long now = Instant.now().getEpochSecond();
+
+    try (Connection c = ds.getConnection()) {
+      try {
+        c.setAutoCommit(false);
+        PlayerSnapshot before = lockPlayer(c, uuid);
+        if (before == null) {
+          insertPlayer(c, uuid, cleanName, seen, now);
+          long seq = nextSeq(c, uuid);
+          c.commit();
+          events.firePlayerRegistered(
+              new CoreEvents.PlayerRegisteredEvent(uuid, seq, cleanName, EVENT_VERSION));
+          return;
+        }
+
+        boolean nameChanged = !before.name().equals(cleanName);
+        boolean seenChanged = !equalsNullable(before.seenAt(), seen);
+        if (!nameChanged && !seenChanged) {
+          c.commit();
+          return;
+        }
+
+        updatePlayer(c, uuid, cleanName, seen, now);
+        long seq = nextSeq(c, uuid);
+        c.commit();
+        events.firePlayerSeenUpdated(
+            new CoreEvents.PlayerSeenUpdatedEvent(
+                uuid,
+                seq,
+                before.name(),
+                cleanName,
+                seen != null ? seen : (before.seenAt() != null ? before.seenAt() : 0L),
+                EVENT_VERSION));
+      } catch (SQLException e) {
+        try {
+          c.rollback();
+        } catch (SQLException ignore) {
+        }
+        throw e;
+      }
+    } catch (SQLException e) {
+      LOG.warn("(mincore) players.upsertSeen failed", e);
+    }
+  }
+
+  @Override
+  public void iteratePlayers(Consumer<PlayerRef> consumer) {
+    if (consumer == null) return;
+    String sql =
+        "SELECT uuid,name,created_at_s,updated_at_s,seen_at_s,balance_units FROM players ORDER BY uuid";
+    try (Connection c = ds.getConnection();
+        PreparedStatement ps = c.prepareStatement(sql);
+        ResultSet rs = ps.executeQuery()) {
+      while (rs.next()) {
+        consumer.accept(mapPlayer(rs));
+      }
+    } catch (SQLException e) {
+      LOG.warn("(mincore) players.iteratePlayers failed", e);
+    }
+  }
+
+  private PlayerSnapshot lockPlayer(Connection c, UUID uuid) throws SQLException {
+    String sql = "SELECT name,seen_at_s FROM players WHERE uuid=? FOR UPDATE";
+    try (PreparedStatement ps = c.prepareStatement(sql)) {
+      ps.setBytes(1, uuidToBytes(uuid));
+      try (ResultSet rs = ps.executeQuery()) {
+        if (rs.next()) {
+          String name = rs.getString("name");
+          long seenRaw = rs.getLong("seen_at_s");
+          boolean seenNull = rs.wasNull();
+          return new PlayerSnapshot(name, seenNull ? null : seenRaw);
+        }
+      }
+    }
+    return null;
+  }
+
+  private void insertPlayer(Connection c, UUID uuid, String name, Long seenAt, long now)
+      throws SQLException {
+    String sql =
+        "INSERT INTO players(uuid,name,balance_units,created_at_s,updated_at_s,seen_at_s) VALUES(?,?,?,?,?,?)";
+    try (PreparedStatement ps = c.prepareStatement(sql)) {
+      ps.setBytes(1, uuidToBytes(uuid));
       ps.setString(2, name);
-      ps.setLong(3, now);
+      ps.setLong(3, 0L);
       ps.setLong(4, now);
       ps.setLong(5, now);
+      if (seenAt == null) {
+        ps.setNull(6, Types.BIGINT);
+      } else {
+        ps.setLong(6, seenAt);
+      }
       ps.executeUpdate();
-    } catch (SQLException e) {
-      LOG.warn("(mincore) ensureAccount failed", e);
     }
   }
 
-  @Override
-  public void syncName(UUID uuid, String name) {
-    String sql =
-        "UPDATE players SET name=?, updated_at_s=? WHERE uuid=UNHEX(REPLACE(?, \"-\", \"\")) AND name<>?";
-    long now = Instant.now().getEpochSecond();
-    try (Connection c = ds.getConnection();
-        PreparedStatement ps = c.prepareStatement(sql)) {
-      c.setAutoCommit(true);
+  private void updatePlayer(Connection c, UUID uuid, String name, Long seenAt, long now)
+      throws SQLException {
+    String sql = "UPDATE players SET name=?, updated_at_s=?, seen_at_s=? WHERE uuid=?";
+    try (PreparedStatement ps = c.prepareStatement(sql)) {
       ps.setString(1, name);
       ps.setLong(2, now);
-      ps.setString(3, uuid.toString());
-      ps.setString(4, name);
+      if (seenAt == null) {
+        ps.setNull(3, Types.BIGINT);
+      } else {
+        ps.setLong(3, seenAt);
+      }
+      ps.setBytes(4, uuidToBytes(uuid));
       ps.executeUpdate();
-    } catch (SQLException e) {
-      LOG.warn("(mincore) syncName failed", e);
     }
   }
 
-  @Override
-  public Optional<PlayerView> getPlayer(UUID uuid) {
-    String sql =
-        "SELECT name,created_at_s,updated_at_s,seen_at_s,balance_units FROM players WHERE uuid=UNHEX(REPLACE(?, \"-\", \"\"))";
-    try (Connection c = ds.getConnection();
-        PreparedStatement ps = c.prepareStatement(sql)) {
-      ps.setString(1, uuid.toString());
-      try (ResultSet rs = ps.executeQuery()) {
+  private long nextSeq(Connection c, UUID uuid) throws SQLException {
+    try (PreparedStatement ps =
+            c.prepareStatement(
+                "INSERT INTO player_event_seq(uuid,seq) VALUES(?,1) "
+                    + "ON DUPLICATE KEY UPDATE seq=LAST_INSERT_ID(seq+1)");
+        Statement last = c.createStatement()) {
+      ps.setBytes(1, uuidToBytes(uuid));
+      ps.executeUpdate();
+      try (ResultSet rs = last.executeQuery("SELECT LAST_INSERT_ID()")) {
         if (rs.next()) {
-          String name = rs.getString(1);
-          long created = rs.getLong(2);
-          long updated = rs.getLong(3);
-          long seen = rs.getLong(4);
-          long bal = rs.getLong(5);
-          final boolean wasNull = rs.wasNull();
-          return Optional.of(
-              new PlayerView() {
-                public UUID uuid() {
-                  return uuid;
-                }
-
-                public String name() {
-                  return name;
-                }
-
-                public long createdAtEpochSeconds() {
-                  return created;
-                }
-
-                public long updatedAtEpochSeconds() {
-                  return updated;
-                }
-
-                public Long seenAtEpochSeconds() {
-                  return wasNull ? null : seen;
-                }
-
-                public long balanceUnits() {
-                  return bal;
-                }
-              });
+          return rs.getLong(1);
         }
       }
-    } catch (SQLException e) {
-      LOG.warn("(mincore) getPlayer failed", e);
     }
-    return Optional.empty();
+    return 0L;
   }
 
-  @Override
-  public Optional<PlayerView> getPlayerByName(String exactName) {
-    String sql =
-        "SELECT uuid,created_at_s,updated_at_s,seen_at_s,balance_units FROM players WHERE name_lower=?";
-    try (Connection c = ds.getConnection();
-        PreparedStatement ps = c.prepareStatement(sql)) {
-      ps.setString(1, exactName.toLowerCase());
-      try (ResultSet rs = ps.executeQuery()) {
-        if (rs.next()) {
-          byte[] u = rs.getBytes(1);
-          long created = rs.getLong(2);
-          long updated = rs.getLong(3);
-          long seen = rs.getLong(4);
-          long bal = rs.getLong(5);
-          final boolean wasNull = rs.wasNull();
-          return Optional.of(
-              new PlayerView() {
-                public java.util.UUID uuid() {
-                  return readUuid(u);
-                }
+  private static PlayerRef mapPlayer(ResultSet rs) throws SQLException {
+    byte[] raw = rs.getBytes("uuid");
+    UUID uuid = raw == null ? null : bytesToUuid(raw);
+    String name = rs.getString("name");
+    long created = rs.getLong("created_at_s");
+    long updated = rs.getLong("updated_at_s");
+    long seenRaw = rs.getLong("seen_at_s");
+    boolean seenNull = rs.wasNull();
+    long balance = rs.getLong("balance_units");
+    Long seen = seenNull ? null : seenRaw;
+    return new DbPlayer(uuid, name, created, updated, seen, balance);
+  }
 
-                public String name() {
-                  return exactName;
-                }
-
-                public long createdAtEpochSeconds() {
-                  return created;
-                }
-
-                public long updatedAtEpochSeconds() {
-                  return updated;
-                }
-
-                public Long seenAtEpochSeconds() {
-                  return wasNull ? null : seen;
-                }
-
-                public long balanceUnits() {
-                  return bal;
-                }
-              });
-        }
-      }
-    } catch (SQLException e) {
-      LOG.warn("(mincore) getPlayerByName failed", e);
+  private static byte[] uuidToBytes(UUID uuid) {
+    long msb = uuid.getMostSignificantBits();
+    long lsb = uuid.getLeastSignificantBits();
+    byte[] out = new byte[16];
+    for (int i = 0; i < 8; i++) {
+      out[i] = (byte) ((msb >>> (8 * (7 - i))) & 0xff);
     }
-    return Optional.empty();
+    for (int i = 0; i < 8; i++) {
+      out[8 + i] = (byte) ((lsb >>> (8 * (7 - i))) & 0xff);
+    }
+    return out;
   }
 
-  @Override
-  public void iteratePlayers(Consumer<PlayerView> consumer, int batchSize) {
-    String sql =
-        "SELECT uuid,name,created_at_s,updated_at_s,seen_at_s,balance_units FROM players ORDER BY uuid LIMIT ? OFFSET ?";
-    int offset = 0, n;
-    do {
-      n = 0;
-      try (Connection c = ds.getConnection();
-          PreparedStatement ps = c.prepareStatement(sql)) {
-        ps.setInt(1, batchSize);
-        ps.setInt(2, offset);
-        try (ResultSet rs = ps.executeQuery()) {
-          while (rs.next()) {
-            n++;
-            byte[] u = rs.getBytes(1);
-            String name = rs.getString(2);
-            long created = rs.getLong(3);
-            long updated = rs.getLong(4);
-            long seen = rs.getLong(5);
-            long bal = rs.getLong(6);
-            final boolean wasNull = rs.wasNull();
-            consumer.accept(
-                new PlayerView() {
-                  public java.util.UUID uuid() {
-                    return readUuid(u);
-                  }
-
-                  public String name() {
-                    return name;
-                  }
-
-                  public long createdAtEpochSeconds() {
-                    return created;
-                  }
-
-                  public long updatedAtEpochSeconds() {
-                    return updated;
-                  }
-
-                  public Long seenAtEpochSeconds() {
-                    return wasNull ? null : seen;
-                  }
-
-                  public long balanceUnits() {
-                    return bal;
-                  }
-                });
-          }
-        }
-      } catch (SQLException e) {
-        LOG.warn("(mincore) iteratePlayers failed", e);
-        break;
-      }
-      offset += n;
-    } while (n == batchSize);
+  private static UUID bytesToUuid(byte[] data) {
+    if (data == null || data.length != 16) return null;
+    long msb = 0;
+    long lsb = 0;
+    for (int i = 0; i < 8; i++) {
+      msb = (msb << 8) | (data[i] & 0xffL);
+    }
+    for (int i = 8; i < 16; i++) {
+      lsb = (lsb << 8) | (data[i] & 0xffL);
+    }
+    return new UUID(msb, lsb);
   }
 
-  /** Converts a 16-byte binary UUID to a Java {@link java.util.UUID}. */
-  private static java.util.UUID readUuid(byte[] b) {
-    if (b == null || b.length != 16) return null;
-    long msb = 0, lsb = 0;
-    for (int i = 0; i < 8; i++) msb = (msb << 8) | (b[i] & 0xff);
-    for (int i = 8; i < 16; i++) lsb = (lsb << 8) | (b[i] & 0xff);
-    return new java.util.UUID(msb, lsb);
+  private static String normalizeNameKey(String name) {
+    return sanitizeName(name).toLowerCase(Locale.ROOT);
   }
+
+  private static String sanitizeName(String name) {
+    String trimmed = name == null ? "" : name.trim();
+    if (trimmed.isEmpty()) {
+      return "unknown";
+    }
+    return trimmed.length() > 32 ? trimmed.substring(0, 32) : trimmed;
+  }
+
+  private static boolean equalsNullable(Long a, Long b) {
+    return a == null ? b == null : a.equals(b);
+  }
+
+  private record PlayerSnapshot(String name, Long seenAt) {}
+
+  private record DbPlayer(
+      UUID uuid, String name, long createdAtS, long updatedAtS, Long seenAtS, long balanceUnits)
+      implements PlayerRef {}
 }

--- a/src/main/java/dev/mincore/util/PlayersX.java
+++ b/src/main/java/dev/mincore/util/PlayersX.java
@@ -2,6 +2,7 @@
 package dev.mincore.util;
 
 import dev.mincore.api.MinCoreApi;
+import dev.mincore.api.Players;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -16,7 +17,7 @@ public final class PlayersX {
    * @return UUID if present now, else empty
    */
   public static Optional<UUID> resolveNameExact(String name) {
-    return MinCoreApi.players().getPlayerByName(name).map(v -> v.uuid());
+    return MinCoreApi.players().byName(name).map(v -> v.uuid());
   }
 
   /**
@@ -26,6 +27,6 @@ public final class PlayersX {
    * @return name if known, else empty
    */
   public static Optional<String> nameOf(UUID uuid) {
-    return MinCoreApi.players().getPlayer(uuid).map(v -> v.name());
+    return MinCoreApi.players().byUuid(uuid).map(Players.PlayerRef::name);
   }
 }


### PR DESCRIPTION
## Summary
- update the Players API and implementation to expose byUuid/byName lookups, upsertSeen, and the new PlayerRef projection while emitting v1 events
- revise wallet handling to use canonical idempotency scopes, enforce balance sequencing, and publish detailed balance change events
- align migrations, ledger listener, and admin ledger commands with the master spec schema

## Testing
- gradle build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d01b2d40c88333a5b8670623567588