### PR TITLE
fix: restore admin commands and ledger wiring

### DIFF
--- a/src/main/java/dev/mincore/MinCoreMod.java
+++ b/src/main/java/dev/mincore/MinCoreMod.java
@@ -88,8 +88,6 @@ public final class MinCoreMod implements ModInitializer {
 
     // 8) Scheduler hooks (backups, sweeps, etc.)
     Scheduler.install(services, cfg);
-    // 8) Scheduler hooks (backups, sweeps, etc.)
-    Scheduler.install(services);
     // 9) Graceful shutdown
     ServerLifecycleEvents.SERVER_STOPPING.register(
         server -> {

--- a/src/main/java/dev/mincore/api/Players.java
+++ b/src/main/java/dev/mincore/api/Players.java
@@ -90,22 +90,6 @@ public interface Players {
      *
      * @return balance in minor units
      */
-    /** Player UUID. */
-    UUID uuid();
-
-    /** Last known username. */
-    String name();
-
-    /** Creation time (epoch seconds, UTC). */
-    long createdAtS();
-
-    /** Last update time (epoch seconds, UTC). */
-    long updatedAtS();
-
-    /** Last seen time (epoch seconds, UTC) or {@code null}. */
-    Long seenAtS();
-
-    /** Wallet balance in smallest currency units. */
     long balanceUnits();
   }
 }

--- a/src/main/java/dev/mincore/commands/AdminCommands.java
+++ b/src/main/java/dev/mincore/commands/AdminCommands.java
@@ -7,25 +7,22 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import dev.mincore.MinCoreMod;
 import dev.mincore.api.Players;
+import dev.mincore.api.Players.PlayerRef;
 import dev.mincore.core.BackupExporter;
+import dev.mincore.core.Config;
 import dev.mincore.core.Scheduler;
 import dev.mincore.core.Services;
 import dev.mincore.util.Timezones;
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
-import dev.mincore.api.Players;
-import dev.mincore.api.storage.ExtensionDatabase;
-import dev.mincore.core.Services;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.util.UUID;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.minecraft.command.CommandRegistryAccess;
@@ -35,7 +32,7 @@ import net.minecraft.text.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Admin/diagnostic commands for MinCore under /mincore (permission level 4). */
+/** Admin/diagnostic commands exposed under /mincore (permission level 4). */
 public final class AdminCommands {
   private static final Logger LOG = LoggerFactory.getLogger("mincore");
   private static final DateTimeFormatter LEDGER_TIME =
@@ -44,210 +41,158 @@ public final class AdminCommands {
   private AdminCommands() {}
 
   /**
-   * Registers all admin commands.
+   * Registers the `/mincore` command tree.
    *
-   * @param services service container used to back command handlers
-
-  private AdminCommands() {}
-
-  /** Hook once during mod init. Call from MinCoreMod.onInitialize() after bootstrap(). */
-  /**
-   * Registers all /mincore admin commands with Brigadier.
-   *
-   * @param services core service container used by command handlers
+   * @param services service container backing command handlers
    */
   public static void register(final Services services) {
     CommandRegistrationCallback.EVENT.register(
         (CommandDispatcher<ServerCommandSource> dispatcher,
             CommandRegistryAccess registryAccess,
-            CommandManager.RegistrationEnvironment environment) -> buildTree(dispatcher, services));
             CommandManager.RegistrationEnvironment environment) -> {
-          buildTree(dispatcher, services);
+          LiteralArgumentBuilder<ServerCommandSource> root =
+              CommandManager.literal("mincore").requires(src -> src.hasPermissionLevel(4));
+
+          LiteralArgumentBuilder<ServerCommandSource> db = CommandManager.literal("db");
+          db.then(
+              CommandManager.literal("ping").executes(ctx -> cmdDbPing(ctx.getSource(), services)));
+          db.then(
+              CommandManager.literal("info").executes(ctx -> cmdDbInfo(ctx.getSource(), services)));
+          root.then(db);
+
+          root.then(
+              CommandManager.literal("diag").executes(ctx -> cmdDiag(ctx.getSource(), services)));
+
+          LiteralArgumentBuilder<ServerCommandSource> ledger = CommandManager.literal("ledger");
+          ledger.then(
+              CommandManager.literal("recent")
+                  .then(
+                      CommandManager.argument("limit", IntegerArgumentType.integer(1, 200))
+                          .executes(
+                              ctx ->
+                                  cmdLedgerRecent(
+                                      ctx.getSource(),
+                                      services,
+                                      IntegerArgumentType.getInteger(ctx, "limit"))))
+                  .executes(ctx -> cmdLedgerRecent(ctx.getSource(), services, 10)));
+          ledger.then(
+              CommandManager.literal("player")
+                  .then(
+                      CommandManager.argument("target", StringArgumentType.string())
+                          .then(
+                              CommandManager.argument("limit", IntegerArgumentType.integer(1, 200))
+                                  .executes(
+                                      ctx ->
+                                          cmdLedgerByPlayer(
+                                              ctx.getSource(),
+                                              services,
+                                              StringArgumentType.getString(ctx, "target"),
+                                              IntegerArgumentType.getInteger(ctx, "limit"))))
+                          .executes(
+                              ctx ->
+                                  cmdLedgerByPlayer(
+                                      ctx.getSource(),
+                                      services,
+                                      StringArgumentType.getString(ctx, "target"),
+                                      10))));
+          ledger.then(
+              CommandManager.literal("addon")
+                  .then(
+                      CommandManager.argument("addonId", StringArgumentType.string())
+                          .then(
+                              CommandManager.argument("limit", IntegerArgumentType.integer(1, 200))
+                                  .executes(
+                                      ctx ->
+                                          cmdLedgerByAddon(
+                                              ctx.getSource(),
+                                              services,
+                                              StringArgumentType.getString(ctx, "addonId"),
+                                              IntegerArgumentType.getInteger(ctx, "limit"))))
+                          .executes(
+                              ctx ->
+                                  cmdLedgerByAddon(
+                                      ctx.getSource(),
+                                      services,
+                                      StringArgumentType.getString(ctx, "addonId"),
+                                      10))));
+          ledger.then(
+              CommandManager.literal("reason")
+                  .then(
+                      CommandManager.argument("substring", StringArgumentType.string())
+                          .then(
+                              CommandManager.argument("limit", IntegerArgumentType.integer(1, 200))
+                                  .executes(
+                                      ctx ->
+                                          cmdLedgerByReason(
+                                              ctx.getSource(),
+                                              services,
+                                              StringArgumentType.getString(ctx, "substring"),
+                                              IntegerArgumentType.getInteger(ctx, "limit"))))
+                          .executes(
+                              ctx ->
+                                  cmdLedgerByReason(
+                                      ctx.getSource(),
+                                      services,
+                                      StringArgumentType.getString(ctx, "substring"),
+                                      10))));
+          root.then(ledger);
+
+          LiteralArgumentBuilder<ServerCommandSource> jobs = CommandManager.literal("jobs");
+          jobs.then(
+              CommandManager.literal("list")
+                  .executes(ctx -> cmdJobsList(ctx.getSource(), services)));
+          jobs.then(
+              CommandManager.literal("run")
+                  .then(
+                      CommandManager.argument("job", StringArgumentType.string())
+                          .executes(
+                              ctx ->
+                                  cmdJobsRun(
+                                      ctx.getSource(), StringArgumentType.getString(ctx, "job")))));
+          root.then(jobs);
+
+          root.then(
+              CommandManager.literal("backup")
+                  .then(
+                      CommandManager.literal("now")
+                          .executes(ctx -> cmdBackupNow(ctx.getSource(), services))));
+
+          dispatcher.register(root);
         });
   }
 
-  private static void buildTree(
-      final CommandDispatcher<ServerCommandSource> dispatcher, final Services services) {
-    LiteralArgumentBuilder<ServerCommandSource> root =
-        CommandManager.literal("mincore").requires(src -> src.hasPermissionLevel(4));
-
-
-    // /mincore
-    LiteralArgumentBuilder<ServerCommandSource> root =
-        CommandManager.literal("mincore").requires(src -> src.hasPermissionLevel(4));
-
-    // /mincore db
-    LiteralArgumentBuilder<ServerCommandSource> db = CommandManager.literal("db");
-    db.then(CommandManager.literal("ping").executes(ctx -> cmdDbPing(ctx.getSource(), services)));
-    db.then(CommandManager.literal("info").executes(ctx -> cmdDbInfo(ctx.getSource(), services)));
-
-    LiteralArgumentBuilder<ServerCommandSource> diag =
-        CommandManager.literal("diag").executes(ctx -> cmdDiag(ctx.getSource(), services));
-
-    LiteralArgumentBuilder<ServerCommandSource> ledger = CommandManager.literal("ledger");
-    // /mincore diag
-    LiteralArgumentBuilder<ServerCommandSource> diag =
-        CommandManager.literal("diag").executes(ctx -> cmdDiag(ctx.getSource(), services));
-
-    // /mincore ledger
-    LiteralArgumentBuilder<ServerCommandSource> ledger = CommandManager.literal("ledger");
-
-    // /mincore ledger recent [limit]
-    ledger.then(
-        CommandManager.literal("recent")
-            .then(
-                CommandManager.argument("limit", IntegerArgumentType.integer(1, 200))
-                    .executes(
-                        ctx ->
-                            cmdLedgerRecent(
-                                ctx.getSource(),
-                                services,
-                                IntegerArgumentType.getInteger(ctx, "limit"))))
-            .executes(ctx -> cmdLedgerRecent(ctx.getSource(), services, 10)));
-
-    // /mincore ledger player <name|uuid> [limit]
-    ledger.then(
-        CommandManager.literal("player")
-            .then(
-                CommandManager.argument("target", StringArgumentType.string())
-                    .then(
-                        CommandManager.argument("limit", IntegerArgumentType.integer(1, 200))
-                            .executes(
-                                ctx ->
-                                    cmdLedgerByPlayer(
-                                        ctx.getSource(),
-                                        services,
-                                        StringArgumentType.getString(ctx, "target"),
-                                        IntegerArgumentType.getInteger(ctx, "limit"))))
-                    .executes(
-                        ctx ->
-                            cmdLedgerByPlayer(
-                                ctx.getSource(),
-                                services,
-                                StringArgumentType.getString(ctx, "target"),
-                                10))));
-
-
-    // /mincore ledger reason <substring> [limit]
-    ledger.then(
-        CommandManager.literal("reason")
-            .then(
-                CommandManager.argument("substring", StringArgumentType.string())
-                    .then(
-                        CommandManager.argument("limit", IntegerArgumentType.integer(1, 200))
-                            .executes(
-                                ctx ->
-                                    cmdLedgerByReason(
-                                        ctx.getSource(),
-                                        services,
-                                        StringArgumentType.getString(ctx, "substring"),
-                                        IntegerArgumentType.getInteger(ctx, "limit"))))
-                    .executes(
-                        ctx ->
-                            cmdLedgerByReason(
-                                ctx.getSource(),
-                                services,
-                                StringArgumentType.getString(ctx, "substring"),
-                                10))));
-
-
-    // /mincore ledger addon <addonId> [limit]
-    ledger.then(
-        CommandManager.literal("addon")
-            .then(
-                CommandManager.argument("addonId", StringArgumentType.string())
-                    .then(
-                        CommandManager.argument("limit", IntegerArgumentType.integer(1, 200))
-                            .executes(
-                                ctx ->
-                                    cmdLedgerByAddon(
-                                        ctx.getSource(),
-                                        services,
-                                        StringArgumentType.getString(ctx, "addonId"),
-                                        IntegerArgumentType.getInteger(ctx, "limit"))))
-                    .executes(
-                        ctx ->
-                            cmdLedgerByAddon(
-                                ctx.getSource(),
-                                services,
-                                StringArgumentType.getString(ctx, "addonId"),
-                                10))));
-
-    LiteralArgumentBuilder<ServerCommandSource> jobs = CommandManager.literal("jobs");
-    jobs.then(CommandManager.literal("list").executes(ctx -> cmdJobsList(ctx.getSource())));
-    jobs.then(
-        CommandManager.literal("run")
-            .then(
-                CommandManager.argument("job", StringArgumentType.string())
-                    .executes(
-                        ctx ->
-                            cmdJobsRun(
-                                ctx.getSource(), StringArgumentType.getString(ctx, "job")))));
-
-    LiteralArgumentBuilder<ServerCommandSource> backup =
-        CommandManager.literal("backup")
-            .then(
-                CommandManager.literal("now")
-                    .executes(ctx -> cmdBackupNow(ctx.getSource(), services)));
-
-    root.then(db);
-    root.then(diag);
-    root.then(ledger);
-    root.then(jobs);
-    root.then(backup);
-    root.then(db);
-    root.then(diag);
-    root.then(ledger);
-
-    dispatcher.register(root);
-  }
-
-  // ----------------------------------------------------------------------
-  // Handlers
-  // ----------------------------------------------------------------------
-
   private static int cmdDbPing(final ServerCommandSource src, final Services services) {
-    long pingMs;
-    try (Connection c = services.database().borrowConnection()) {
-      long t0 = System.nanoTime();
-      try (PreparedStatement ps = c.prepareStatement("SELECT 1")) {
-        try (ResultSet rs = ps.executeQuery()) {
-      try (java.sql.Statement st = c.createStatement()) {
-        try (ResultSet rs = st.executeQuery("SELECT 1")) {
-          while (rs.next()) {
-            // drain
-          }
+    try (Connection c = services.database().borrowConnection();
+        PreparedStatement ps = c.prepareStatement("SELECT 1")) {
+      long start = System.nanoTime();
+      try (ResultSet rs = ps.executeQuery()) {
+        while (rs.next()) {
+          // drain
         }
       }
-      pingMs = (System.nanoTime() - t0) / 1_000_000L;
-      src.sendFeedback(() -> Text.translatable("mincore.cmd.db.ping.ok", pingMs), false);
+      long tookMs = Math.max(0, (System.nanoTime() - start) / 1_000_000L);
+      src.sendFeedback(() -> Text.translatable("mincore.cmd.db.ping.ok", tookMs), false);
       return 1;
     } catch (Exception e) {
       LOG.warn("(mincore) /mincore db ping failed", e);
       src.sendFeedback(
           () -> Text.translatable("mincore.cmd.db.ping.fail", e.getClass().getSimpleName()), false);
-      final String msg = "DB OK: connect=pooled, ping=" + pingMs + "ms";
-      src.sendFeedback(() -> Text.literal(msg), false);
-      return 1;
-    } catch (Exception e) {
-      LOG.warn("(mincore) /mincore db ping failed", e);
-      final String msg = "DB ERROR: " + e.getClass().getSimpleName() + ": " + e.getMessage();
-      src.sendFeedback(() -> Text.literal(msg), false);
       return 0;
     }
   }
 
   private static int cmdDbInfo(final ServerCommandSource src, final Services services) {
     try (Connection c = services.database().borrowConnection()) {
-      DatabaseMetaData md = c.getMetaData();
-      String url = safe(md.getURL());
-      String product =
-          safe(md.getDatabaseProductName()) + " " + safe(md.getDatabaseProductVersion());
+      var md = c.getMetaData();
+      String url = md.getURL();
+      String product = md.getDatabaseProductName() + " " + md.getDatabaseProductVersion();
       String isolation = isolationName(c.getTransactionIsolation());
-      var cfg = MinCoreMod.config();
+
+      Config cfg = MinCoreMod.config();
       String host = cfg != null ? cfg.db().host() : "?";
       int port = cfg != null ? cfg.db().port() : -1;
       boolean tls = cfg != null && cfg.db().tlsEnabled();
+
       src.sendFeedback(
           () ->
               Text.translatable(
@@ -264,16 +209,6 @@ public final class AdminCommands {
       LOG.warn("(mincore) /mincore db info failed", e);
       src.sendFeedback(
           () -> Text.translatable("mincore.cmd.db.ping.fail", e.getClass().getSimpleName()), false);
-      java.sql.DatabaseMetaData md = c.getMetaData();
-      final String url = safe(md.getURL());
-      final String product =
-          safe(md.getDatabaseProductName()) + " " + safe(md.getDatabaseProductVersion());
-      src.sendFeedback(() -> Text.literal("DB: " + url + " (" + product + ")"), false);
-      return 1;
-    } catch (Exception e) {
-      LOG.warn("(mincore) /mincore db info failed", e);
-      final String msg = "DB ERROR: " + e.getClass().getSimpleName() + ": " + e.getMessage();
-      src.sendFeedback(() -> Text.literal(msg), false);
       return 0;
     }
   }
@@ -313,36 +248,14 @@ public final class AdminCommands {
       src.sendFeedback(() -> Text.translatable("mincore.cmd.diag.schemaMissing"), false);
     }
     return false;
-    int ok = 1;
-    try (Connection c = services.database().borrowConnection()) {
-      src.sendFeedback(() -> Text.literal("Database   : OK (borrowed from pool)"), false);
-      try (java.sql.Statement st = c.createStatement()) {
-        try (ResultSet rs = st.executeQuery("SELECT @@session.time_zone")) {
-          if (rs.next()) {
-            final String tz = rs.getString(1);
-            src.sendFeedback(() -> Text.literal("SessionTZ  : " + tz), false);
-          }
-        }
-      }
-    } catch (Exception e) {
-      ok = 0;
-      src.sendFeedback(
-          () -> Text.literal("Database   : ERROR " + e.getClass().getSimpleName()), false);
-    }
-    return ok;
   }
 
   private static int cmdLedgerRecent(
       final ServerCommandSource src, final Services services, final int limit) {
     final String sql =
-        "SELECT id, ts_s, addon_id, op, from_uuid, to_uuid, amount, reason, ok, code, seq, idem_scope, old_units, new_units, server_node, extra_json "
+        "SELECT ts_s, addon_id, op, from_uuid, to_uuid, amount, reason, ok, code "
             + "FROM core_ledger ORDER BY id DESC LIMIT ?";
     return printLedger(src, services, sql, ps -> ps.setInt(1, Math.max(1, limit)));
-        "SELECT id, ts_s, addon_id, op, from_uuid, to_uuid, amount, reason, ok, code, seq, idem_scope "
-            + "FROM core_ledger "
-            + "ORDER BY id DESC "
-            + "LIMIT ?";
-    return printLedger(src, services.database(), sql, ps -> ps.setInt(1, Math.max(1, limit)));
   }
 
   private static int cmdLedgerByPlayer(
@@ -352,64 +265,28 @@ public final class AdminCommands {
       final int limit) {
     UUID uuid = tryParseUuid(target);
     if (uuid == null) {
-      Players.PlayerRef pv = services.players().byName(target).orElse(null);
-      if (pv == null) {
+      Players players = services.players();
+      PlayerRef ref = players.byName(target).orElse(null);
+      if (ref == null) {
         src.sendFeedback(() -> Text.translatable("mincore.err.player.unknown"), false);
-        src.sendFeedback(() -> Text.literal("No player matched: " + target), false);
         return 0;
       }
-      uuid = pv.uuid();
+      uuid = ref.uuid();
     }
-    final UUID u = uuid;
 
+    final UUID u = uuid;
     final String sql =
-        "SELECT id, ts_s, addon_id, op, from_uuid, to_uuid, amount, reason, ok, code, seq, idem_scope, old_units, new_units, server_node, extra_json "
+        "SELECT ts_s, addon_id, op, from_uuid, to_uuid, amount, reason, ok, code "
             + "FROM core_ledger WHERE from_uuid = ? OR to_uuid = ? ORDER BY id DESC LIMIT ?";
     return printLedger(
         src,
         services,
-
-        "SELECT id, ts_s, addon_id, op, from_uuid, to_uuid, amount, reason, ok, code, seq, idem_scope "
-            + "FROM core_ledger "
-            + "WHERE from_uuid = ? OR to_uuid = ? "
-            + "ORDER BY id DESC "
-            + "LIMIT ?";
-    return printLedger(
-        src,
-        services.database(),
         sql,
         ps -> {
-          ps.setBytes(1, uuidToBytes(u));
-          ps.setBytes(2, uuidToBytes(u));
+          byte[] b = uuidToBytes(u);
+          ps.setBytes(1, b);
+          ps.setBytes(2, b);
           ps.setInt(3, Math.max(1, limit));
-        });
-  }
-
-  private static int cmdLedgerByReason(
-      final ServerCommandSource src,
-      final Services services,
-      final String needle,
-      final int limit) {
-    final String like = "%" + needle + "%";
-    final String sql =
-        "SELECT id, ts_s, addon_id, op, from_uuid, to_uuid, amount, reason, ok, code, seq, idem_scope, old_units, new_units, server_node, extra_json "
-            + "FROM core_ledger WHERE reason LIKE ? ORDER BY id DESC LIMIT ?";
-    return printLedger(
-        src,
-        services,
-
-        "SELECT id, ts_s, addon_id, op, from_uuid, to_uuid, amount, reason, ok, code, seq, idem_scope "
-            + "FROM core_ledger "
-            + "WHERE reason LIKE ? "
-            + "ORDER BY id DESC "
-            + "LIMIT ?";
-    return printLedger(
-        src,
-        services.database(),
-        sql,
-        ps -> {
-          ps.setString(1, like);
-          ps.setInt(2, Math.max(1, limit));
         });
   }
 
@@ -419,19 +296,11 @@ public final class AdminCommands {
       final String addonId,
       final int limit) {
     final String sql =
-        "SELECT id, ts_s, addon_id, op, from_uuid, to_uuid, amount, reason, ok, code, seq, idem_scope, old_units, new_units, server_node, extra_json "
+        "SELECT ts_s, addon_id, op, from_uuid, to_uuid, amount, reason, ok, code "
             + "FROM core_ledger WHERE addon_id = ? ORDER BY id DESC LIMIT ?";
     return printLedger(
         src,
         services,
-        "SELECT id, ts_s, addon_id, op, from_uuid, to_uuid, amount, reason, ok, code, seq, idem_scope "
-            + "FROM core_ledger "
-            + "WHERE addon_id = ? "
-            + "ORDER BY id DESC "
-            + "LIMIT ?";
-    return printLedger(
-        src,
-        services.database(),
         sql,
         ps -> {
           ps.setString(1, addonId);
@@ -439,84 +308,22 @@ public final class AdminCommands {
         });
   }
 
-  private static int cmdJobsList(ServerCommandSource src) {
-    src.sendFeedback(() -> Text.translatable("mincore.cmd.jobs.header"), false);
-    for (Scheduler.JobStatus status : Scheduler.jobs()) {
-      src.sendFeedback(
-          () ->
-              Text.translatable(
-                  "mincore.cmd.jobs.line",
-                  status.name,
-                  status.schedule,
-                  status.nextRun,
-                  status.lastRun,
-                  status.running,
-                  status.successCount,
-                  status.failureCount,
-                  status.lastError == null ? "" : status.lastError),
-          false);
-    }
-    return 1;
-  }
-
-  private static int cmdJobsRun(ServerCommandSource src, String job) {
-    boolean ok = Scheduler.runNow(job);
-    if (ok) {
-      src.sendFeedback(() -> Text.translatable("mincore.cmd.jobs.run.ok", job), false);
-      return 1;
-    }
-    src.sendFeedback(() -> Text.translatable("mincore.cmd.jobs.run.unknown", job), false);
-    return 0;
-  }
-
-  private static int cmdBackupNow(ServerCommandSource src, Services services) {
-    final var server = src.getServer();
-    services
-        .scheduler()
-        .submit(
-            () -> {
-              try {
-                var cfg = MinCoreMod.config();
-                if (cfg == null) {
-                  server.execute(
-                      () ->
-                          src.sendFeedback(
-                              () -> Text.translatable("mincore.cmd.backup.fail", "config"), false));
-                  return;
-                }
-                var result = BackupExporter.exportAll(services, cfg);
-                server.execute(
-                    () ->
-                        src.sendFeedback(
-                            () ->
-                                Text.translatable(
-                                    "mincore.cmd.backup.ok",
-                                    result.file().getFileName().toString(),
-                                    result.players(),
-                                    result.attributes(),
-                                    result.ledger()),
-                            false));
-              } catch (Exception e) {
-                LOG.warn("(mincore) manual backup failed", e);
-                server.execute(
-                    () ->
-                        src.sendFeedback(
-                            () -> Text.translatable("mincore.cmd.backup.fail", e.getMessage()),
-                            false));
-              }
-            });
-    src.sendFeedback(() -> Text.translatable("mincore.cmd.backup.started"), false);
-    return 1;
-  }
-
-  private interface Binder {
-  // ----------------------------------------------------------------------
-  // Helpers
-  // ----------------------------------------------------------------------
-
-  @FunctionalInterface
-  private interface PStmt {
-    void bind(PreparedStatement ps) throws Exception;
+  private static int cmdLedgerByReason(
+      final ServerCommandSource src,
+      final Services services,
+      final String needle,
+      final int limit) {
+    final String sql =
+        "SELECT ts_s, addon_id, op, from_uuid, to_uuid, amount, reason, ok, code "
+            + "FROM core_ledger WHERE reason LIKE ? ORDER BY id DESC LIMIT ?";
+    return printLedger(
+        src,
+        services,
+        sql,
+        ps -> {
+          ps.setString(1, "%" + needle + "%");
+          ps.setInt(2, Math.max(1, limit));
+        });
   }
 
   private static int printLedger(
@@ -524,157 +331,202 @@ public final class AdminCommands {
       final Services services,
       final String sql,
       final Binder binder) {
+    List<LedgerRow> rows = new ArrayList<>();
     try (Connection c = services.database().borrowConnection();
-      final ExtensionDatabase db,
-      final String sql,
-      final PStmt binder) {
-    try (Connection c = db.borrowConnection();
         PreparedStatement ps = c.prepareStatement(sql)) {
       binder.bind(ps);
       try (ResultSet rs = ps.executeQuery()) {
-        int count = 0;
-        src.sendFeedback(() -> Text.translatable("mincore.cmd.ledger.header"), false);
-        ZoneId zone = Timezones.resolve(src, services);
-        src.sendFeedback(() -> Text.literal("— recent ledger entries —"), false);
         while (rs.next()) {
-          long id = rs.getLong("id");
-          long ts = rs.getLong("ts_s");
-          String addon = safe(rs.getString("addon_id"));
-          String op = safe(rs.getString("op"));
-          long amount = rs.getLong("amount");
-          boolean ok = rs.getBoolean("ok");
-          String code = safe(rs.getString("code"));
-          long seq = rs.getLong("seq");
-          String scope = safe(rs.getString("idem_scope"));
-          String fromStr = formatUuid(rs.getBytes("from_uuid"));
-          String toStr = formatUuid(rs.getBytes("to_uuid"));
-          String reason = safe(rs.getString("reason"));
-          String serverNode = safe(rs.getString("server_node"));
-          String extra = safe(rs.getString("extra_json"));
-          long oldUnits = rs.getLong("old_units");
-          long newUnits = rs.getLong("new_units");
-
-          Text line =
-              Text.translatable(
-                  "mincore.cmd.ledger.line",
-                  id,
-                  LEDGER_TIME.format(Instant.ofEpochSecond(ts).atZone(zone)),
-                  addon,
-                  op,
-                  amount,
-                  ok,
-                  code,
-                  seq,
-                  scope,
-                  fromStr,
-                  toStr,
-                  reason,
-                  oldUnits,
-                  newUnits,
-                  serverNode,
-                  extra);
-          src.sendFeedback(() -> line, false);
-          count++;
-        }
-        if (count == 0) {
-          src.sendFeedback(() -> Text.translatable("mincore.cmd.ledger.none"), false);
-
-          StringBuilder line =
-              new StringBuilder()
-                  .append('#')
-                  .append(id)
-                  .append(" ts=")
-                  .append(ts)
-                  .append(" [")
-                  .append(addon)
-                  .append(':')
-                  .append(op)
-                  .append("] amt=")
-                  .append(amount)
-                  .append(" ok=")
-                  .append(ok ? "ok" : "fail")
-                  .append(" seq=")
-                  .append(seq)
-                  .append(" scope=")
-                  .append(scope.isEmpty() ? "-" : scope)
-                  .append(" from=")
-                  .append(fromStr)
-                  .append(" to=")
-                  .append(toStr)
-                  .append(" reason=")
-                  .append(reason.isEmpty() ? "-" : reason);
-          if (!code.isEmpty()) {
-            line.append(" code=").append(code);
-          }
-
-          final String fline = line.toString();
-          src.sendFeedback(() -> Text.literal(fline), false);
-          count++;
-        }
-        if (count == 0) {
-          src.sendFeedback(() -> Text.literal("(no rows)"), false);
+          rows.add(
+              new LedgerRow(
+                  rs.getLong(1),
+                  rs.getString(2),
+                  rs.getString(3),
+                  readUuid(rs, 4),
+                  readUuid(rs, 5),
+                  rs.getLong(6),
+                  rs.getString(7),
+                  rs.getBoolean(8),
+                  rs.getString(9)));
         }
       }
-      return 1;
     } catch (Exception e) {
       LOG.warn("(mincore) ledger query failed", e);
+      src.sendFeedback(() -> Text.translatable("mincore.err.db.unavailable"), false);
+      return 0;
+    }
+
+    if (rows.isEmpty()) {
+      src.sendFeedback(() -> Text.translatable("mincore.cmd.ledger.none"), false);
+      return 1;
+    }
+
+    ZoneId zone = Timezones.resolve(src, services);
+    DateTimeFormatter fmt = LEDGER_TIME.withZone(zone);
+    Players players = services.players();
+    src.sendFeedback(
+        () -> Text.translatable("mincore.cmd.ledger.header", rows.size(), zone.getId()), false);
+    for (LedgerRow row : rows) {
+      String when = fmt.format(Instant.ofEpochSecond(row.ts()));
+      String from = formatPlayer(players, row.from());
+      String to = formatPlayer(players, row.to());
       src.sendFeedback(
-          () -> Text.translatable("mincore.cmd.ledger.error", e.getClass().getSimpleName()), false);
-      final String msg = "Ledger ERROR: " + e.getClass().getSimpleName() + ": " + e.getMessage();
-      src.sendFeedback(() -> Text.literal(msg), false);
+          () ->
+              Text.translatable(
+                  "mincore.cmd.ledger.line",
+                  when,
+                  row.addon(),
+                  row.op(),
+                  row.amount(),
+                  from,
+                  to,
+                  row.reason(),
+                  row.ok(),
+                  row.code() == null ? "" : row.code()),
+          false);
+    }
+    return 1;
+  }
+
+  private static int cmdJobsList(final ServerCommandSource src, final Services services) {
+    List<Scheduler.JobStatus> jobs = Scheduler.jobs();
+    ZoneId zone = Timezones.resolve(src, services);
+    DateTimeFormatter fmt = LEDGER_TIME.withZone(zone);
+    if (jobs.isEmpty()) {
+      src.sendFeedback(() -> Text.translatable("mincore.cmd.jobs.list.none"), false);
+      return 1;
+    }
+    src.sendFeedback(() -> Text.translatable("mincore.cmd.jobs.list.header", zone.getId()), false);
+    for (Scheduler.JobStatus job : jobs) {
+      String next = job.nextRun != null ? fmt.format(job.nextRun) : "-";
+      String last = job.lastRun != null ? fmt.format(job.lastRun) : "-";
+      String error = job.lastError == null ? "" : job.lastError;
+      src.sendFeedback(
+          () ->
+              Text.translatable(
+                  "mincore.cmd.jobs.list.line",
+                  job.name,
+                  job.schedule,
+                  job.description,
+                  next,
+                  last,
+                  job.running,
+                  job.successCount,
+                  job.failureCount,
+                  error),
+          false);
+    }
+    return 1;
+  }
+
+  private static int cmdJobsRun(final ServerCommandSource src, final String job) {
+    boolean scheduled = Scheduler.runNow(job);
+    if (scheduled) {
+      src.sendFeedback(() -> Text.translatable("mincore.cmd.jobs.run.ok", job), false);
+      return 1;
+    }
+    src.sendFeedback(() -> Text.translatable("mincore.cmd.jobs.run.unknown", job), false);
+    return 0;
+  }
+
+  private static int cmdBackupNow(final ServerCommandSource src, final Services services) {
+    Config cfg = MinCoreMod.config();
+    if (cfg == null) {
+      src.sendFeedback(() -> Text.translatable("mincore.cmd.backup.fail", "config"), false);
+      return 0;
+    }
+    try {
+      BackupExporter.Result result = BackupExporter.exportAll(services, cfg);
+      src.sendFeedback(
+          () ->
+              Text.translatable(
+                  "mincore.cmd.backup.ok",
+                  result.file().toString(),
+                  result.players(),
+                  result.attributes(),
+                  result.ledger()),
+          false);
+      return 1;
+    } catch (Exception e) {
+      LOG.warn("(mincore) /mincore backup now failed", e);
+      src.sendFeedback(
+          () -> Text.translatable("mincore.cmd.backup.fail", e.getClass().getSimpleName()), false);
       return 0;
     }
   }
 
-  private static String safe(String s) {
-    return s == null ? "" : s;
-  }
-
-  private static String isolationName(int iso) {
-    return switch (iso) {
+  private static String isolationName(int level) {
+    return switch (level) {
       case Connection.TRANSACTION_NONE -> "NONE";
-      case Connection.TRANSACTION_READ_UNCOMMITTED -> "READ_UNCOMMITTED";
       case Connection.TRANSACTION_READ_COMMITTED -> "READ_COMMITTED";
+      case Connection.TRANSACTION_READ_UNCOMMITTED -> "READ_UNCOMMITTED";
       case Connection.TRANSACTION_REPEATABLE_READ -> "REPEATABLE_READ";
       case Connection.TRANSACTION_SERIALIZABLE -> "SERIALIZABLE";
-      default -> String.valueOf(iso);
+      default -> "UNKNOWN";
     };
-    return (s == null) ? "" : s;
   }
 
-  private static String formatUuid(byte[] raw) {
-    if (raw == null || raw.length != 16) {
+  private static UUID tryParseUuid(String raw) {
+    try {
+      return UUID.fromString(raw);
+    } catch (Exception ignored) {
+      return null;
+    }
+  }
+
+  private static String formatPlayer(Players players, UUID uuid) {
+    if (uuid == null) {
       return "-";
     }
-    long msb = 0;
-    long lsb = 0;
-    for (int i = 0; i < 8; i++) {
-      msb = (msb << 8) | (raw[i] & 0xffL);
-    }
-    for (int i = 8; i < 16; i++) {
-      lsb = (lsb << 8) | (raw[i] & 0xffL);
-    }
-    return new UUID(msb, lsb).toString();
+    PlayerRef ref = players.byUuid(uuid).orElse(null);
+    return ref != null ? ref.name() : uuid.toString();
   }
 
-  private static byte[] uuidToBytes(UUID uuid) {
-    long msb = uuid.getMostSignificantBits();
-    long lsb = uuid.getLeastSignificantBits();
+  private static byte[] uuidToBytes(UUID u) {
+    if (u == null) {
+      return null;
+    }
     byte[] out = new byte[16];
+    long msb = u.getMostSignificantBits();
+    long lsb = u.getLeastSignificantBits();
     for (int i = 0; i < 8; i++) {
-      out[i] = (byte) ((msb >>> (8 * (7 - i))) & 0xff);
+      out[i] = (byte) (msb >>> (8 * (7 - i)));
     }
     for (int i = 0; i < 8; i++) {
-      out[8 + i] = (byte) ((lsb >>> (8 * (7 - i))) & 0xff);
+      out[8 + i] = (byte) (lsb >>> (8 * (7 - i)));
     }
     return out;
   }
 
-  private static UUID tryParseUuid(String s) {
-    try {
-      return UUID.fromString(s);
-    } catch (Exception ignored) {
+  private static UUID readUuid(ResultSet rs, int index) throws SQLException {
+    byte[] bytes = rs.getBytes(index);
+    if (bytes == null || bytes.length != 16) {
       return null;
     }
+    long msb = 0;
+    long lsb = 0;
+    for (int i = 0; i < 8; i++) {
+      msb = (msb << 8) | (bytes[i] & 0xff);
+    }
+    for (int i = 8; i < 16; i++) {
+      lsb = (lsb << 8) | (bytes[i] & 0xff);
+    }
+    return new UUID(msb, lsb);
+  }
+
+  private record LedgerRow(
+      long ts,
+      String addon,
+      String op,
+      UUID from,
+      UUID to,
+      long amount,
+      String reason,
+      boolean ok,
+      String code) {}
+
+  @FunctionalInterface
+  private interface Binder {
+    void bind(PreparedStatement ps) throws SQLException;
   }
 }

--- a/src/main/java/dev/mincore/core/Migrations.java
+++ b/src/main/java/dev/mincore/core/Migrations.java
@@ -16,10 +16,8 @@ public final class Migrations {
   /**
    * Applies idempotent DDL. Each statement is executed independently; failures are logged and the
    * migrator proceeds with remaining statements.
-
    *
    * @param services service container supplying the database connection
-
    */
   public static void apply(Services services) {
     final String[] ddl = {

--- a/src/main/java/dev/mincore/core/WalletsImpl.java
+++ b/src/main/java/dev/mincore/core/WalletsImpl.java
@@ -25,7 +25,6 @@ public final class WalletsImpl implements Wallets {
   private final DataSource ds;
   private final EventBus events;
 
-
   /**
    * Creates a wallet service backed by the given datasource and event bus.
    *

--- a/src/main/java/dev/mincore/util/Currency.java
+++ b/src/main/java/dev/mincore/util/Currency.java
@@ -33,11 +33,7 @@ public final class Currency {
     if (s == null) {
       throw new IllegalArgumentException("Input may not be null");
     }
-    String t =
-        s.replace("_", "")
-            .replace(",", "")
-            .trim()
-            .toLowerCase(Locale.ROOT);
+    String t = s.replace("_", "").replace(",", "").trim().toLowerCase(Locale.ROOT);
     double base;
     long mul = 1L;
     if (t.endsWith("k")) {


### PR DESCRIPTION
## Summary
- rebuild `/mincore` admin command tree to expose db, ledger, job, and backup handlers with timezone-aware output
- fix ledger installation to use the configured datasource once, recreate the table, and respect retention scheduling
- clean duplicate scheduler installation and tidy API docs/formatting to satisfy Spotless

## Testing
- gradle test
- gradle spotlessCheck

------
https://chatgpt.com/codex/tasks/task_e_68d033c19ee483338965b3237beef039