### PR TITLE
docs: add contributor and ops resources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to MinCore
+
+Welcome! MinCore is a small but opinionated core for Fabric servers. This document summarises the
+process for proposing changes and ensures they stay aligned with the v0.2.0 master specification.
+
+## Getting Started
+
+1. Fork the repository and clone it locally.
+2. Install the toolchain: JDK 21, Gradle 8.1.4+, Fabric Loom 1.11.x, and a MariaDB 10.6+ instance
+   for integration tests.
+3. Run the formatter and checks once before you begin:
+   ```sh
+   ./gradlew spotlessApply check
+   ```
+4. Configure a local `config/mincore.json5` (the loader writes a commented default on first run).
+
+## Development Workflow
+
+* Create feature branches from `development` (or the default working branch) and keep pull requests
+  focused.
+* Follow Conventional Commits for messages, for example `feat: add cron audit logging`.
+* Provide JavaDoc on all new public APIs and keep error handling mapped to `ErrorCode` values.
+* Never block the Minecraft main thread with JDBC or other I/O—hop to async executors via the
+  service container.
+* Prefer idempotent wallet operations and include reason strings suitable for operators.
+* When touching scheduled jobs or migrations, use advisory locks and document failure behaviour.
+
+## Coding Standards
+
+* Source is formatted using Spotless with Google Java Style. Run `./gradlew spotlessApply` before
+  committing.
+* Keep timestamps in UTC seconds and store UUIDs as `BINARY(16)` when writing migrations.
+* New localization keys belong in `assets/mincore/lang/en_us.json`; update translations and run
+  `./gradlew validateI18n`.
+* Surface operator/player messages through the translation files and include appropriate placeholders
+  for dynamic data.
+
+## Testing Checklist
+
+Before submitting a pull request:
+
+1. `./gradlew build` – compiles sources and runs unit tests.
+2. `./gradlew validateI18n` – ensures locale files stay in sync.
+3. If your change touches the database, run the smoke test workflow in `docs/SMOKE_TEST.md` against a
+   local MariaDB instance.
+4. Capture manual verification notes (commands run, results observed) in the pull request body.
+
+## Reporting Issues
+
+* Include server logs around the failure with `(mincore)` tags.
+* Provide schema version, Minecraft/Fabric versions, and MariaDB server version.
+* Describe the steps to reproduce, including any add-ons interacting with MinCore APIs.
+
+Thank you for helping us keep MinCore reliable and operator-friendly!

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -1,0 +1,21 @@
+# MinCore Error Code Catalogue
+
+MinCore surfaces canonical `ErrorCode` values across wallet operations, admin commands, and logs.
+Use this table to map failures to localisation keys and recommended operator actions.
+
+| Code | i18n Key | Typical Source | Operator Guidance |
+| ---- | -------- | -------------- | ----------------- |
+| `INSUFFICIENT_FUNDS` | `mincore.err.economy.insufficient` | Withdraw/transfer attempts | Inform players their balance is too low; review ledger entries for suspicious drains. |
+| `INVALID_AMOUNT` | `mincore.err.economy.invalid` | Negative/zero amount validation | Check the caller for bad arguments or overflow. |
+| `UNKNOWN_PLAYER` | `mincore.err.player.unknown` | Missing UUID/name in players table | Ensure the target has joined the server; verify UUID casing. |
+| `IDEMPOTENCY_REPLAY` | `mincore.err.idem.replay` | Wallet operation repeated with same payload | Safe no-op; investigate why the upstream retried. |
+| `IDEMPOTENCY_MISMATCH` | `mincore.err.idem.mismatch` | Reused idempotency key with different payload | Treat as poisoned; audit the caller for duplicate keys. |
+| `DEADLOCK_RETRY_EXHAUSTED` | `mincore.err.db.deadlock` | withRetry exhausted for SQL deadlock/timeout | Re-run the command once load subsides; inspect DB metrics. |
+| `CONNECTION_LOST` | `mincore.err.db.unavailable` | Hikari unable to reach MariaDB | Check database availability, credentials, and TLS configuration. |
+| `DEGRADED_MODE` | `mincore.err.db.degraded` | Core refusing writes while reconnecting | Resolve database outage; writes will resume once connectivity returns. |
+| `MIGRATION_LOCKED` | `mincore.err.migrate.locked` | Migrations held by another node | Wait for the other process or clear the advisory lock manually. |
+| `NAME_AMBIGUOUS` | `mincore.err.player.ambiguous` | `/mincore ledger player <name>` duplicate matches | Use the UUID to disambiguate players with similar names. |
+| `INVALID_TZ` | `mincore.err.tz.invalid` | `/timezone set` with bad zone ID | Provide a valid [IANA Zone ID](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). |
+| `OVERRIDES_DISABLED` | `mincore.err.tz.overridesDisabled` | Overrides disabled in config | Update `core.time.display.allowPlayerOverride` or advise players it’s locked. |
+
+All error codes are defined in [`src/main/java/dev/mincore/api/ErrorCode.java`](../src/main/java/dev/mincore/api/ErrorCode.java) and logged with the `(mincore)` prefix for easy filtering.

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -1,0 +1,54 @@
+# MinCore Smoke Test (Ops-Grade)
+
+The script and checklist below exercise the production guarantees described in the v0.2.0 master
+spec. Run it against a staging server before upgrades and after significant configuration changes.
+
+## Prerequisites
+
+* Fabric server running MinCore with operator access (RCON recommended).
+* MariaDB instance seeded with the MinCore schema.
+* Two throwaway player accounts you can join with for verification.
+* `mcrcon` (or any RCON CLI) installed locally.
+
+Export the following environment variables if you want to drive the automated script in
+`scripts/smoke-test.sh`:
+
+```sh
+export MINCORE_RCON_HOST=127.0.0.1
+export MINCORE_RCON_PORT=25575
+export MINCORE_RCON_PASSWORD=change-me
+```
+
+## Manual Checklist
+
+1. **Database connectivity**
+   * `/mincore db ping`
+   * `/mincore db info`
+   * `/mincore diag`
+2. **Player bootstrap**
+   * Join with Player A, run `/playtime me` (should show a few seconds).
+   * Run `/mincore ledger recent 5` and confirm the ledger header prints.
+3. **Wallet operations**
+   * Run `wallet deposit` via console or add-on to give Player A 1,000 units (use idempotent API
+     with a unique key).
+   * Transfer 250 units from Player A to Player B twice with the same idempotency key – the second
+     invocation should return an `IDEMPOTENCY_REPLAY` code and the ledger should not duplicate the
+     transfer.
+4. **Scheduler verification**
+   * `/mincore jobs list` – ensure `backup` and `cleanup.idempotencySweep` are present with sane
+     next-run timestamps.
+   * `/mincore jobs run backup` – confirm the job queues.
+   * Inspect the backup directory for a new `mincore-*.jsonl.gz` and `.sha256` checksum.
+5. **Backup + restore**
+   * `/mincore backup now` – expect `mincore.cmd.backup.queued` feedback.
+   * Use `/mincore export --all --out ./backups/mincore --gzip true`.
+   * Copy the generated archive aside; test `/mincore restore --mode fresh --atomic --from <dir>` on a
+     staging database.
+6. **Doctor**
+   * `/mincore doctor --counts --fk` – confirm reported counts match expectations and no FK issues.
+7. **Timezone & I18n**
+   * If overrides are enabled, run `/timezone set Europe/Berlin` as a player and ensure success.
+   * Toggle JSON logging and ensure locale messages render correctly in your configured language.
+
+Record the commands issued and their responses in your change log or pull request before marking the
+run successful.

--- a/examples/hello-ledger/README.md
+++ b/examples/hello-ledger/README.md
@@ -1,0 +1,95 @@
+# Hello Ledger Example Add-on
+
+This minimal Fabric add-on demonstrates how to bootstrap against MinCore’s APIs:
+
+* Listen for `PlayerRegisteredEvent` to grant a welcome bonus.
+* Use idempotent wallet operations to avoid duplicate deposits.
+* Localise messages and respect player timezones.
+
+## Project Layout
+
+```
+examples/hello-ledger/
+├─ build.gradle.kts        # Minimal Loom build (see snippet below)
+├─ src/main/java/dev/mincore/example/HelloLedgerMod.java
+├─ src/main/resources/
+│  ├─ fabric.mod.json
+│  └─ assets/helloledger/lang/en_us.json
+└─ README.md (this file)
+```
+
+The example is not wired into the root Gradle build to keep the core lean—copy the folder beside
+your Fabric mod workspace and import it as a separate module.
+
+## Key Snippets
+
+### Gradle Build Script (`build.gradle.kts`)
+
+```kotlin
+plugins {
+  id("fabric-loom") version "1.11-SNAPSHOT"
+}
+
+java.sourceCompatibility = JavaVersion.VERSION_21
+java.targetCompatibility = JavaVersion.VERSION_21
+
+repositories {
+  mavenCentral()
+  maven("https://maven.fabricmc.net/")
+}
+
+dependencies {
+  minecraft("com.mojang:minecraft:${rootProject.extra["minecraft_version"]}")
+  mappings("net.fabricmc:yarn:${rootProject.extra["yarn_mappings"]}:v2")
+  modImplementation("net.fabricmc:fabric-loader:${rootProject.extra["loader_version"]}")
+  modImplementation("net.fabricmc.fabric-api:fabric-api:${rootProject.extra["fabric_version"]}")
+  modImplementation(files("../mincore/build/libs/mincore-${rootProject.version}.jar"))
+}
+```
+
+### Mod Initialiser (`HelloLedgerMod.java`)
+
+```java
+public final class HelloLedgerMod implements ModInitializer {
+  private static final String ADDON_ID = "hello-ledger";
+
+  @Override
+  public void onInitialize() {
+    MinCoreApi.events()
+        .onPlayerRegistered(
+            event -> {
+              UUID player = event.player();
+              String reason = "hello-ledger:welcome";
+              String idem = "hello-ledger:welcome:" + player;
+              Wallets.OperationResult result =
+                  MinCoreApi.wallets().depositResult(player, 100L, reason, idem);
+              if (result.ok()) {
+                MinCoreApi.ledger()
+                    .log(
+                        ADDON_ID,
+                        "welcome-bonus",
+                        null,
+                        player,
+                        100L,
+                        reason,
+                        true,
+                        null,
+                        "hello-ledger",
+                        idem,
+                        null);
+              }
+            });
+  }
+}
+```
+
+### Localisation (`assets/helloledger/lang/en_us.json`)
+
+```json
+{
+  "helloledger.msg.bonus": "Welcome to the server! A 100 unit bonus was added to your wallet."
+}
+```
+
+Use `MinCoreApi.players()` to resolve names for notifications and
+`Timezones.resolve(source, services)` if you need to render timestamps for players.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${MINCORE_RCON_HOST:-}" == "" || "${MINCORE_RCON_PASSWORD:-}" == "" ]]; then
+  cat <<'MSG'
+Configure MINCORE_RCON_HOST, MINCORE_RCON_PORT (defaults to 25575), and MINCORE_RCON_PASSWORD to
+run the automated smoke test via RCON. See docs/SMOKE_TEST.md for the manual checklist.
+MSG
+  exit 1
+fi
+
+HOST=${MINCORE_RCON_HOST}
+PORT=${MINCORE_RCON_PORT:-25575}
+PASS=${MINCORE_RCON_PASSWORD}
+RCON_BIN=${MINCORE_RCON_BIN:-mcrcon}
+
+run() {
+  local cmd=$1
+  echo "[mincore-smoke] $cmd"
+  ${RCON_BIN} -H "${HOST}" -P "${PORT}" -p "${PASS}" "${cmd}"
+}
+
+run "mincore db ping"
+run "mincore db info"
+run "mincore diag"
+run "mincore jobs list"
+run "mincore jobs run backup"
+run "mincore backup now"
+run "mincore ledger recent 5"
+run "mincore doctor --counts"
+
+echo "[mincore-smoke] Automated portion complete. Finish manual steps in docs/SMOKE_TEST.md."

--- a/src/main/java/dev/mincore/core/BackupImporter.java
+++ b/src/main/java/dev/mincore/core/BackupImporter.java
@@ -63,6 +63,7 @@ public final class BackupImporter {
    * @param ledger number of ledger rows imported
    */
   public record Result(Path source, long players, long attributes, long eventSeq, long ledger) {}
+
   private record Header(String version, int schemaVersion, String defaultZone) {}
 
   /**


### PR DESCRIPTION
## Summary
- add a CONTRIBUTING guide that captures workflow, style and testing requirements from the v0.2.0 spec
- document the ops smoke test, error code catalogue, and supply a Hello Ledger add-on example for authors
- provide an automated RCON smoke-test helper script to complement the manual checklist

## Testing
- gradle check --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d06fdac45c83339cf3488a1f77755f