### PR TITLE
feat: add wallet results and schema tooling

### DIFF
--- a/src/main/java/dev/mincore/core/CoreServices.java
+++ b/src/main/java/dev/mincore/core/CoreServices.java
@@ -142,10 +142,10 @@ public final class CoreServices implements Services, java.io.Closeable {
 
     EventBus events = new EventBus();
     Metrics metrics = new Metrics();
-    ExtensionDbImpl ext = new ExtensionDbImpl(ds, dbHealth);
-    Players players = new PlayersImpl(ds, events, dbHealth);
+    ExtensionDbImpl ext = new ExtensionDbImpl(ds, dbHealth, metrics);
+    Players players = new PlayersImpl(ds, events, dbHealth, metrics);
     Wallets wallets = new WalletsImpl(ds, events, dbHealth, metrics);
-    Attributes attrs = new AttributesImpl(ds, dbHealth);
+    Attributes attrs = new AttributesImpl(ds, dbHealth, metrics);
     PlaytimeImpl play = new PlaytimeImpl();
 
     // Track playtime via Fabric connection events
@@ -220,6 +220,10 @@ public final class CoreServices implements Services, java.io.Closeable {
 
   DbHealth dbHealth() {
     return dbHealth;
+  }
+
+  Metrics metrics() {
+    return metrics;
   }
 
   private static boolean isLocalHost(String host) {

--- a/src/main/java/dev/mincore/core/SchemaHelperImpl.java
+++ b/src/main/java/dev/mincore/core/SchemaHelperImpl.java
@@ -2,11 +2,22 @@
 package dev.mincore.core;
 
 import dev.mincore.api.storage.SchemaHelper;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.sql.DataSource;
 
 /** Basic implementation backed by information_schema. */
 final class SchemaHelperImpl implements SchemaHelper {
+  private static final Pattern TABLE_PATTERN =
+      Pattern.compile(
+          "(?i)create\\s+table\\s+(if\\s+not\\s+exists\\s+)?(?:(`)([^`]+)`|([a-z0-9_\\.]+))");
   private final DataSource ds;
 
   SchemaHelperImpl(DataSource ds) {
@@ -14,22 +25,45 @@ final class SchemaHelperImpl implements SchemaHelper {
   }
 
   @Override
-  public void ensureTable(String createSql) throws java.sql.SQLException {
-    try (var c = ds.getConnection();
-        var st = c.createStatement()) {
-      st.execute(createSql);
+  public void ensureTable(String createSql) throws SQLException {
+    ensureTable(extractTableName(createSql), createSql);
+  }
+
+  @Override
+  public void ensureTable(String table, String createSql) throws SQLException {
+    Objects.requireNonNull(createSql, "createSql");
+    String candidate = table != null ? table : extractTableName(createSql);
+    if (candidate != null && tableExists(candidate)) {
+      return;
+    }
+    execute(createSql);
+  }
+
+  @Override
+  public boolean tableExists(String table) throws SQLException {
+    String sql =
+        """
+      SELECT COUNT(*) FROM information_schema.tables
+      WHERE table_schema = DATABASE() AND table_name = ?
+      """;
+    try (Connection c = ds.getConnection();
+        PreparedStatement ps = c.prepareStatement(sql)) {
+      ps.setString(1, table);
+      try (ResultSet rs = ps.executeQuery()) {
+        return rs.next() && rs.getInt(1) > 0;
+      }
     }
   }
 
   @Override
-  public boolean hasColumn(String table, String column) throws java.sql.SQLException {
+  public boolean hasColumn(String table, String column) throws SQLException {
     String sql =
         """
       SELECT COUNT(*) FROM information_schema.columns
       WHERE table_schema = DATABASE() AND table_name=? AND column_name=?
       """;
-    try (var c = ds.getConnection();
-        var ps = c.prepareStatement(sql)) {
+    try (Connection c = ds.getConnection();
+        PreparedStatement ps = c.prepareStatement(sql)) {
       ps.setString(1, table);
       ps.setString(2, column);
       try (ResultSet rs = ps.executeQuery()) {
@@ -40,55 +74,133 @@ final class SchemaHelperImpl implements SchemaHelper {
 
   @Override
   public void addColumnIfMissing(String table, String column, String columnDef)
-      throws java.sql.SQLException {
+      throws SQLException {
     if (hasColumn(table, column)) return;
-    try (var c = ds.getConnection();
-        var st = c.createStatement()) {
-      st.execute("ALTER TABLE " + table + " ADD COLUMN " + column + " " + columnDef);
-    }
+    execute("ALTER TABLE " + table + " ADD COLUMN " + column + " " + columnDef);
   }
 
   @Override
-  public void ensureIndex(String table, String indexName, String createIndexSql)
-      throws java.sql.SQLException {
+  public boolean hasIndex(String table, String indexName) throws SQLException {
     String sql =
         """
       SELECT COUNT(*) FROM information_schema.statistics
       WHERE table_schema = DATABASE() AND table_name=? AND index_name=?
       """;
-    try (var c = ds.getConnection();
-        var ps = c.prepareStatement(sql)) {
+    try (Connection c = ds.getConnection();
+        PreparedStatement ps = c.prepareStatement(sql)) {
       ps.setString(1, table);
       ps.setString(2, indexName);
       try (ResultSet rs = ps.executeQuery()) {
-        if (rs.next() && rs.getInt(1) > 0) return;
+        return rs.next() && rs.getInt(1) > 0;
       }
-    }
-    try (var c = ds.getConnection();
-        var st = c.createStatement()) {
-      st.execute(createIndexSql);
     }
   }
 
   @Override
-  public void ensureCheck(String table, String checkName, String addCheckSql)
-      throws java.sql.SQLException {
+  public void ensureIndex(String table, String indexName, String createIndexSql)
+      throws SQLException {
+    if (hasIndex(table, indexName)) {
+      return;
+    }
+    execute(createIndexSql);
+  }
+
+  @Override
+  public void ensureCheck(String table, String checkName, String addCheckSql) throws SQLException {
+    if (hasCheck(table, checkName)) {
+      return;
+    }
+    execute(addCheckSql);
+  }
+
+  @Override
+  public boolean hasCheck(String table, String checkName) throws SQLException {
     String sql =
         """
       SELECT COUNT(*) FROM information_schema.table_constraints
       WHERE constraint_schema = DATABASE() AND table_name=? AND constraint_name=? AND constraint_type='CHECK'
       """;
-    try (var c = ds.getConnection();
-        var ps = c.prepareStatement(sql)) {
+    try (Connection c = ds.getConnection();
+        PreparedStatement ps = c.prepareStatement(sql)) {
       ps.setString(1, table);
       ps.setString(2, checkName);
       try (ResultSet rs = ps.executeQuery()) {
-        if (rs.next() && rs.getInt(1) > 0) return;
+        return rs.next() && rs.getInt(1) > 0;
       }
     }
-    try (var c = ds.getConnection();
-        var st = c.createStatement()) {
-      st.execute(addCheckSql);
+  }
+
+  @Override
+  public boolean hasPrimaryKey(String table, String constraintName) throws SQLException {
+    return hasConstraint(table, constraintName, "PRIMARY KEY");
+  }
+
+  @Override
+  public void ensurePrimaryKey(String table, String constraintName, String addPrimaryKeySql)
+      throws SQLException {
+    if (hasPrimaryKey(table, constraintName)) {
+      return;
     }
+    execute(addPrimaryKeySql);
+  }
+
+  @Override
+  public boolean hasForeignKey(String table, String constraintName) throws SQLException {
+    return hasConstraint(table, constraintName, "FOREIGN KEY");
+  }
+
+  @Override
+  public void ensureForeignKey(String table, String constraintName, String addForeignKeySql)
+      throws SQLException {
+    if (hasForeignKey(table, constraintName)) {
+      return;
+    }
+    execute(addForeignKeySql);
+  }
+
+  private boolean hasConstraint(String table, String constraintName, String type)
+      throws SQLException {
+    String sql =
+        """
+      SELECT COUNT(*) FROM information_schema.table_constraints
+      WHERE constraint_schema = DATABASE() AND table_name=? AND constraint_name=? AND constraint_type=?
+      """;
+    try (Connection c = ds.getConnection();
+        PreparedStatement ps = c.prepareStatement(sql)) {
+      ps.setString(1, table);
+      ps.setString(2, constraintName);
+      ps.setString(3, type);
+      try (ResultSet rs = ps.executeQuery()) {
+        return rs.next() && rs.getInt(1) > 0;
+      }
+    }
+  }
+
+  private void execute(String sql) throws SQLException {
+    try (Connection c = ds.getConnection();
+        Statement st = c.createStatement()) {
+      st.execute(sql);
+    }
+  }
+
+  private static String extractTableName(String createSql) {
+    if (createSql == null) {
+      return null;
+    }
+    Matcher matcher = TABLE_PATTERN.matcher(createSql);
+    if (!matcher.find()) {
+      return null;
+    }
+    String backtickName = matcher.group(3);
+    String plainName = matcher.group(4);
+    String raw = backtickName != null ? backtickName : plainName;
+    if (raw == null) {
+      return null;
+    }
+    String normalized = raw.trim();
+    if (normalized.contains(".")) {
+      normalized = normalized.substring(normalized.lastIndexOf('.') + 1);
+    }
+    return normalized.toLowerCase(Locale.ROOT);
   }
 }

--- a/src/main/java/dev/mincore/core/SqlErrorCodes.java
+++ b/src/main/java/dev/mincore/core/SqlErrorCodes.java
@@ -6,7 +6,7 @@ import java.sql.SQLException;
 import java.util.Locale;
 
 /** Utility that maps JDBC {@link SQLException} instances to MinCore {@link ErrorCode}s. */
-final class SqlErrorCodes {
+public final class SqlErrorCodes {
 
   private SqlErrorCodes() {}
 
@@ -16,7 +16,7 @@ final class SqlErrorCodes {
    * @param e SQL exception thrown by MariaDB/MySQL
    * @return mapped {@link ErrorCode}, defaulting to {@link ErrorCode#CONNECTION_LOST}
    */
-  static ErrorCode classify(SQLException e) {
+  public static ErrorCode classify(SQLException e) {
     if (e == null) {
       return ErrorCode.CONNECTION_LOST;
     }

--- a/src/test/java/dev/mincore/core/MariaDbTestSupport.java
+++ b/src/test/java/dev/mincore/core/MariaDbTestSupport.java
@@ -1,0 +1,76 @@
+/* MinCore © 2025 — MIT */
+package dev.mincore.core;
+
+import ch.vorburger.mariadb4j.DB;
+import ch.vorburger.mariadb4j.DBConfigurationBuilder;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/** Shared embedded MariaDB lifecycle for integration tests. */
+final class MariaDbTestSupport {
+  static final String USER = "root";
+  static final String PASSWORD = "";
+
+  private static final DB EMBEDDED_DB;
+  private static final int PORT;
+  private static final String BASE_URL;
+
+  static {
+    try {
+      Class.forName("org.mariadb.jdbc.Driver");
+      DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
+      builder.setPort(0);
+      builder.setDeletingTemporaryBaseAndDataDirsOnShutdown(true);
+      builder.setSecurityDisabled(true);
+      builder.addArg("--user=" + USER);
+      EMBEDDED_DB = DB.newEmbeddedDB(builder.build());
+      EMBEDDED_DB.start();
+      PORT = EMBEDDED_DB.getConfiguration().getPort();
+      BASE_URL = "jdbc:mariadb://127.0.0.1:" + PORT + "/";
+      Runtime.getRuntime()
+          .addShutdownHook(
+              new Thread(
+                  () -> {
+                    try {
+                      EMBEDDED_DB.stop();
+                    } catch (Exception ignored) {
+                    }
+                  }));
+    } catch (Exception e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private MariaDbTestSupport() {}
+
+  static void ensureDatabase(String name) throws SQLException {
+    try (Connection c = DriverManager.getConnection(baseUrl("mysql"), USER, PASSWORD);
+        Statement st = c.createStatement()) {
+      st.executeUpdate(
+          "CREATE DATABASE IF NOT EXISTS "
+              + name
+              + " CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    }
+  }
+
+  static void dropDatabase(String name) throws SQLException {
+    try (Connection c = DriverManager.getConnection(baseUrl("mysql"), USER, PASSWORD);
+        Statement st = c.createStatement()) {
+      st.executeUpdate("DROP DATABASE IF EXISTS " + name);
+    }
+  }
+
+  static String jdbcUrl(String database) {
+    return baseUrl(database) + "?useUnicode=true&characterEncoding=utf8mb4&serverTimezone=UTC";
+  }
+
+  static int port() {
+    return PORT;
+  }
+
+  private static String baseUrl(String schema) {
+    return BASE_URL + schema;
+  }
+}

--- a/src/test/java/dev/mincore/core/TestConfigFactory.java
+++ b/src/test/java/dev/mincore/core/TestConfigFactory.java
@@ -1,0 +1,59 @@
+/* MinCore © 2025 — MIT */
+package dev.mincore.core;
+
+import java.lang.reflect.Constructor;
+import java.nio.file.Path;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Locale;
+
+/** Builds minimal {@link Config} instances for integration tests. */
+final class TestConfigFactory {
+  private TestConfigFactory() {}
+
+  static Config create(String dbName, Path backupDir) throws Exception {
+    Config.Db dbConfig =
+        new Config.Db(
+            "127.0.0.1",
+            MariaDbTestSupport.port(),
+            dbName,
+            MariaDbTestSupport.USER,
+            MariaDbTestSupport.PASSWORD,
+            false,
+            true,
+            new Config.Pool(4, 1, 10_000L, 60_000L, 120_000L, 1));
+
+    Config.Runtime runtime = new Config.Runtime(5);
+    Config.Time time = new Config.Time(new Config.Display(ZoneId.of("UTC"), false, false));
+    Config.I18n i18n =
+        new Config.I18n(
+            Locale.forLanguageTag("en-US"), List.of("en_US"), Locale.forLanguageTag("en-US"));
+    Config.Ledger ledger =
+        new Config.Ledger(
+            true, 0, new Config.JsonlMirror(false, backupDir.resolve("ledger.jsonl").toString()));
+    Config.Backup backup =
+        new Config.Backup(
+            true,
+            "0 45 4 * * *",
+            backupDir.toString(),
+            Config.OnMissed.RUN_AT_NEXT_STARTUP,
+            false,
+            new Config.Prune(30, 10));
+    Config.Cleanup cleanup =
+        new Config.Cleanup(new Config.IdempotencySweep(true, "0 30 4 * * *", 30, 5_000));
+    Config.Jobs jobs = new Config.Jobs(backup, cleanup);
+    Config.Log log = new Config.Log(false, 250L, "INFO");
+
+    Constructor<Config> ctor =
+        Config.class.getDeclaredConstructor(
+            Config.Db.class,
+            Config.Runtime.class,
+            Config.Time.class,
+            Config.I18n.class,
+            Config.Ledger.class,
+            Config.Jobs.class,
+            Config.Log.class);
+    ctor.setAccessible(true);
+    return ctor.newInstance(dbConfig, runtime, time, i18n, ledger, jobs, log);
+  }
+}

--- a/src/test/java/dev/mincore/core/TestFiles.java
+++ b/src/test/java/dev/mincore/core/TestFiles.java
@@ -1,0 +1,29 @@
+/* MinCore © 2025 — MIT */
+package dev.mincore.core;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** Test utilities for filesystem operations. */
+final class TestFiles {
+  private TestFiles() {}
+
+  static void deleteRecursively(Path path) {
+    if (path == null || Files.notExists(path)) {
+      return;
+    }
+    try {
+      Files.walk(path)
+          .sorted(java.util.Comparator.reverseOrder())
+          .forEach(
+              p -> {
+                try {
+                  Files.deleteIfExists(p);
+                } catch (IOException ignored) {
+                }
+              });
+    } catch (IOException ignored) {
+    }
+  }
+}

--- a/src/test/java/dev/mincore/core/WalletIdempotencyTest.java
+++ b/src/test/java/dev/mincore/core/WalletIdempotencyTest.java
@@ -1,0 +1,126 @@
+/* MinCore © 2025 — MIT */
+package dev.mincore.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.mincore.api.ErrorCode;
+import dev.mincore.api.Wallets;
+import dev.mincore.api.Wallets.OperationResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Integration tests covering wallet idempotency edge cases. */
+final class WalletIdempotencyTest {
+  private static final String DB_NAME = "mincore_wallet_test";
+
+  private CoreServices services;
+  private Wallets wallets;
+  private Path tempDir;
+
+  @BeforeAll
+  static void createDatabase() throws Exception {
+    MariaDbTestSupport.ensureDatabase(DB_NAME);
+  }
+
+  @AfterAll
+  static void dropDatabase() throws Exception {
+    MariaDbTestSupport.dropDatabase(DB_NAME);
+  }
+
+  @BeforeEach
+  void setUp() throws Exception {
+    tempDir = Files.createTempDirectory("wallet-it");
+    Config config = TestConfigFactory.create(DB_NAME, tempDir);
+    services = (CoreServices) CoreServices.start(config);
+    Migrations.apply(services);
+    wallets = services.wallets();
+    registerPlayer(UUID.fromString("00000000-0000-0000-0000-000000000001"), "Alice");
+    registerPlayer(UUID.fromString("00000000-0000-0000-0000-000000000002"), "Bob");
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    try {
+      if (services != null) {
+        services.shutdown();
+      }
+    } finally {
+      wipeTables();
+      if (tempDir != null) {
+        TestFiles.deleteRecursively(tempDir);
+        tempDir = null;
+      }
+    }
+  }
+
+  @Test
+  void depositReplayReturnsSemanticCode() {
+    UUID player = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    String key = "test-key";
+    OperationResult first = wallets.depositResult(player, 1_000L, "bonus", key);
+    assertTrue(first.ok());
+    OperationResult replay = wallets.depositResult(player, 1_000L, "bonus", key);
+    assertTrue(replay.ok());
+    assertEquals(ErrorCode.IDEMPOTENCY_REPLAY, replay.code());
+    assertEquals(1_000L, wallets.getBalance(player));
+  }
+
+  @Test
+  void depositMismatchFailsWithErrorCode() {
+    UUID player = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    String key = "mismatch-key";
+    OperationResult first = wallets.depositResult(player, 2_000L, "event", key);
+    assertTrue(first.ok());
+    OperationResult mismatch = wallets.depositResult(player, 3_000L, "event", key);
+    assertFalse(mismatch.ok());
+    assertEquals(ErrorCode.IDEMPOTENCY_MISMATCH, mismatch.code());
+    assertEquals(2_000L, wallets.getBalance(player));
+  }
+
+  @Test
+  void transferReplayIsIdempotentAcrossPlayers() {
+    UUID alice = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    UUID bob = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    wallets.depositResult(alice, 5_000L, "seed", "seed-key");
+    String key = "transfer-key";
+    OperationResult first = wallets.transferResult(alice, bob, 1_500L, "gift", key);
+    assertTrue(first.ok());
+    OperationResult replay = wallets.transferResult(alice, bob, 1_500L, "gift", key);
+    assertTrue(replay.ok());
+    assertEquals(ErrorCode.IDEMPOTENCY_REPLAY, replay.code());
+    assertEquals(3_500L, wallets.getBalance(alice));
+    assertEquals(1_500L, wallets.getBalance(bob));
+  }
+
+  private void registerPlayer(UUID uuid, String name) {
+    services.players().upsertSeen(uuid, name, Instant.now().getEpochSecond());
+  }
+
+  private void wipeTables() throws SQLException {
+    try (Connection c =
+            DriverManager.getConnection(
+                MariaDbTestSupport.jdbcUrl(DB_NAME),
+                MariaDbTestSupport.USER,
+                MariaDbTestSupport.PASSWORD);
+        Statement st = c.createStatement()) {
+      st.executeUpdate("DELETE FROM core_ledger");
+      st.executeUpdate("DELETE FROM player_attributes");
+      st.executeUpdate("DELETE FROM player_event_seq");
+      st.executeUpdate("DELETE FROM core_requests");
+      st.executeUpdate("DELETE FROM players");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Wallets.OperationResult rich result variants and propagate metrics/error code logging across services
- expand SchemaHelper capabilities and strengthen configuration validation and scheduler/job error handling
- introduce MariaDB-backed test utilities with wallet idempotency integration coverage

## Testing
- gradle check

------
https://chatgpt.com/codex/tasks/task_e_68d534851514833385fe99a03967aa57