### PR TITLE
chore: bump project version to 1.0.0

### DIFF
--- a/ADDON_DEVELOPER_GUIDE.md
+++ b/ADDON_DEVELOPER_GUIDE.md
@@ -1,10 +1,10 @@
 
-# MinCore Add-On Developer Guide (v0.2.0)
+# MinCore Add-On Developer Guide (v1.0.0)
 
 Audience: Java developers building server-side Fabric add-ons that depend on MinCore.  
 Goal: Give you everything you need to build against MinCore correctly on the first try, with clear contracts, examples, and patterns.
 
-> Source of truth is MinCore Master Spec v0.2.0. This guide restates the key parts for add-on authors and adds hands-on examples.
+> Source of truth is MinCore Master Spec v1.0.0. This guide restates the key parts for add-on authors and adds hands-on examples.
 
 ---
 
@@ -85,7 +85,7 @@ plugins {
 }
 
 group = 'dev.yourorg'
-version = '0.1.0'
+version = '1.0.0'
 sourceCompatibility = JavaVersion.VERSION_21
 targetCompatibility = JavaVersion.VERSION_21
 
@@ -102,10 +102,10 @@ dependencies {
 
   // Choose one of the following based on how you obtain MinCore:
   // 1) Local file in your project
-  // modImplementation files("libs/mincore-v0.2.0.jar")
+  // modImplementation files("libs/mincore-v1.0.0.jar")
 
   // 2) Or if published to Maven
-  // modImplementation "dev.mincore:mincore:0.2.0"
+  // modImplementation "dev.mincore:mincore:1.0.0"
 
   // You do not need to add the MariaDB driver to your add-on, the server owner provides it
 }
@@ -133,7 +133,7 @@ Declare a dependency on MinCore so your add-on loads after it.
 {
   "schemaVersion": 1,
   "id": "hello_addon",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "name": "Hello Addon",
   "environment": "server",
   "entrypoints": {
@@ -143,7 +143,7 @@ Declare a dependency on MinCore so your add-on loads after it.
     "fabricloader": ">=0.17.2",
     "minecraft": "1.21.8",
     "fabric-api": "*",
-    "mincore": ">=0.2.0"
+    "mincore": ">=1.0.0"
   }
 }
 ```
@@ -602,7 +602,7 @@ MinCore’s internal jobs use a cron parser. For your add-on, rely on executors 
 ## Checklist Before Release
 
 - [ ] Gradle builds and runs on Java 21
-- [ ] Declares depends on mincore >= 0.2.0
+- [ ] Declares depends on mincore >= 1.0.0
 - [ ] Migrations wrapped in advisory locks, idempotent DDL verified
 - [ ] Wallet operations use idempotency keys
 - [ ] Commands handle ambiguous names and missing players

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# AGENTS.md — MinCore v0.2.0 (Unified & Consistent)
+# AGENTS.md — MinCore v1.0.0 (Unified & Consistent)
 
-This document is a **machine-operable specification** of MinCore v0.2.0 for code agents (e.g., Codex, tool-using LLMs).
+This document is a **machine-operable specification** of MinCore v1.0.0 for code agents (e.g., Codex, tool-using LLMs).
 It **fully encodes** the unified master spec, reorganized into **actionable sections**, **APIs**, **schemas**, **commands**, **rules**, **checklists**, and **step-by-step procedures**. Treat this as the **single source of truth** unless the user explicitly overrides it.
 
 > Scope: Fabric Minecraft server mod named **MinCore** that provides DB access/migrations, economy wallets + ledger (with idempotency), events, scheduler, playtime, i18n, timezone rendering, JSONL backup/export/import, and ops tooling.
@@ -54,7 +54,7 @@ Gameplay content; web UI; poly-DB targets; default PII; heavy schedulers/buses; 
 
 SchemaHelper; Wallets (+idempotency); Ledger (+JSONL mirror); ordered post-commit Events; UTC Scheduler (+backup job); Playtime; I18n/TZ helpers.
 
-### Roadmap (v0.2.0 highlights)
+### Roadmap (v1.0.0 highlights)
 
 Commented JSON5; backup 04:45 UTC; least-priv DB; Config Template Writer; `/timezone`; `/mincore diag`, `/mincore db`, `/mincore ledger`, `/playtime`, `/mincore jobs ...`, `/mincore backup now`; dev standards (Spotless, JavaDoc, error codes), example add-on, smoke test.
 
@@ -544,4 +544,4 @@ See Sections 3.9 and 5.2 for SQL and Docker snippets.
 
 ---
 
-**End of AGENTS.md — MinCore v0.2.0 (Unified & Consistent)**
+**End of AGENTS.md — MinCore v1.0.0 (Unified & Consistent)**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to MinCore
 
 Welcome! MinCore is a small but opinionated core for Fabric servers. This document summarises the
-process for proposing changes and ensures they stay aligned with the v0.2.0 master specification.
+process for proposing changes and ensures they stay aligned with the v1.0.0 master specification.
 
 ## Getting Started
 

--- a/MinCore_Master_Spec.md
+++ b/MinCore_Master_Spec.md
@@ -1,6 +1,6 @@
-# MinCore Master Spec (v0.2.0) — Unified & Consistent
+# MinCore Master Spec (v1.0.0) — Unified & Consistent
 
-> This is the consolidated, internally consistent master specification for **MinCore v0.2.0**.  
+> This is the consolidated, internally consistent master specification for **MinCore v1.0.0**.  
 > It resolves prior naming/terminology clashes (e.g., **backup vs export**, **db info vs db status**), aligns commands/APIs across all parts, and improves section flow.  
 > Treat this as the **sole source of truth** unless you explicitly override it.
 
@@ -35,7 +35,7 @@ MinCore is a **small, opinionated core** for Fabric Minecraft servers that gives
 - **Playtime**: in‑memory tracker.
 - **I18n + TZ rendering** helpers.
 
-### 1.5 Roadmap Snapshot (v0.2.0 highlights)
+### 1.5 Roadmap Snapshot (v1.0.0 highlights)
 
 - Commented JSON5 config; backups 04:45 UTC; least‑priv DB; **Config Template Writer**.
 - Server TZ default, optional per‑player TZ; **/timezone**.
@@ -505,4 +505,4 @@ Branches (`development`), small PRs, Conventional Commits, PR template, code own
 
 ---
 
-**End of MinCore v0.2.0 — Unified & Consistent Master Spec**
+**End of MinCore v1.0.0 — Unified & Consistent Master Spec**

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A small, opinionated core for Fabric Minecraft servers that gives add-on authors production grade primitives. MinCore focuses on database access with safe schema evolution, wallets with a durable ledger, events, a simple scheduler, playtime, i18n, and timezone rendering. The goal is to help you build add-ons faster with fewer foot guns and more predictable operations.
 
-> Source of truth: **MinCore Master Spec v0.2.0**. Treat that spec as authoritative.
+> Source of truth: **MinCore Master Spec v1.0.0**. Treat that spec as authoritative.
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'dev.mincore'
-version = '0.1.0'
+version = '1.0.0'
 
 java {
   toolchain { languageVersion = JavaLanguageVersion.of(21) }

--- a/config/mincore.json5
+++ b/config/mincore.json5
@@ -1,4 +1,4 @@
-// MinCore v0.2.0 configuration
+// MinCore v1.0.0 configuration
 {
   core: {
     db: {

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -1,6 +1,6 @@
 # MinCore Smoke Test (Ops-Grade)
 
-The script and checklist below exercise the production guarantees described in the v0.2.0 master
+The script and checklist below exercise the production guarantees described in the v1.0.0 master
 spec. Run it against a staging server before upgrades and after significant configuration changes.
 
 ## Prerequisites

--- a/src/main/java/dev/mincore/MinCoreMod.java
+++ b/src/main/java/dev/mincore/MinCoreMod.java
@@ -50,7 +50,7 @@ public final class MinCoreMod implements ModInitializer {
   /** Initializes MinCore when Fabric loads the mod. */
   @Override
   public void onInitialize() {
-    LOG.info("(mincore) booting MinCore 0.2.0");
+    LOG.info("(mincore) booting MinCore 1.0.0");
     // 1) Ensure MariaDB driver is present before the pool tries to connect.
     dev.mincore.jdbc.DriverLoader.tryLoadMariaDbDriver();
 

--- a/src/main/java/dev/mincore/core/Config.java
+++ b/src/main/java/dev/mincore/core/Config.java
@@ -30,7 +30,7 @@ public final class Config {
 
   private static final String TEMPLATE =
       """
-      // MinCore v0.2.0 configuration (JSON5 with comments)
+      // MinCore v1.0.0 configuration (JSON5 with comments)
       // Drop into config/mincore.json5. Environment overrides: MINCORE_DB_HOST|PORT|DATABASE|USER|PASSWORD.
       {
         core: {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "mincore",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "name": "MinCore",
   "description": "MariaDB-backed core services for Fabric servers (players, wallets, attributes, events).",
   "authors": ["YourName"],


### PR DESCRIPTION
## Summary
- bump the published mod version to 1.0.0 in build metadata and runtime logging
- refresh the specification, docs, and configuration templates to reference MinCore v1.0.0

## Testing
- gradle test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d5677cd7c88333a354f21865de4f3d