### PR TITLE
Add LuckPerms-first permission gateway

### DIFF
--- a/ADDON_DEVELOPER_GUIDE.md
+++ b/ADDON_DEVELOPER_GUIDE.md
@@ -530,6 +530,22 @@ Provide simple commands that call MinCore. Example, /hello balance <player>
 - If multiple matches, show a short list with UUIDs
 - Then call Wallets.getBalance and render using your i18n
 
+MinCore now ships a LuckPerms-first permission gateway under `dev.mincore.perms.Perms`. Use it at
+the top of every command handler instead of depending on Fabric Permissions yourself.
+
+```java
+if (!Perms.check(player, "youraddon.command.balance", 3)) {
+  player.sendMessage(Text.translatable("youraddon.err.permission"));
+  return 0;
+}
+```
+
+- Run checks on the server thread so LuckPerms user data is loaded.
+- Pick sensible vanilla fallbacks: level `4` for admin-only flows, `3` for high-trust staff, `2`
+  for moderators, `0` for everyone.
+- When running async logic, switch back to the main thread before calling
+  `Perms.checkUUID(server, uuid, node, level)`.
+
 ## Localization and Messages
 
 - Put your locales in assets/<your_mod_id>/lang/en_us.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -540,6 +540,14 @@ FLUSH PRIVILEGES;
 
 `./gradlew clean build` • `./gradlew runServer` • minimal config shown in Part 3.
 
+### 5.3a Permission Gateway (LuckPerms-first)
+
+- **Detection order:** MinCore resolves permissions using LuckPerms (via `LuckPermsProvider` and the cached user data) first, then the Fabric Permissions API when available, and finally vanilla operator levels as the fallback. All lookups should execute on the server thread so LuckPerms user data is already cached.
+- **No hard deps:** Keep LuckPerms and Fabric Permissions API as `compileOnly` dependencies. Ship MinCore without bundling either implementation jar.
+- **Helper API:** Use `dev.mincore.perms.Perms` from commands and services. Example: `if (!Perms.check(player, "mincore.addon.command", 4)) { /* deny */ }`. For off-thread work, hop back to the main thread and call `Perms.checkUUID(server, uuid, node, opLevel)` if needed.
+- **Node naming:** Prefix permissions with `mincore.` or your add-on id, e.g. `mincore.admin.jobs.run` or `youraddon.feature.use`. Keep lowercase dot-separated segments.
+- **Op levels:** Level `4` for full admin, `3` for high-trust staff, `2` for moderation, `0` for everyone. Choose the fallback that mirrors the command’s intended audience.
+
 ### 5.4 One‑Shot Smoke Test
 
 1) `/mincore db ping|info`  

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ MinCore does not include a full gameplay economy, shops, quests, or a web panel.
 - Daily JSONL exports with gzip and checksum files
 - Playtime service with top, me and reset
 - i18n and timezone rendering utilities
+- LuckPerms-first permission helper with Fabric Permissions API and vanilla fallbacks
 - Config Template Writer that generates a complete commented example
 
 ## Requirements

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ dependencies {
   // Driver is provided externally on disk; compileOnly is fine for IDEs.
   compileOnly "org.mariadb.jdbc:mariadb-java-client:3.4.1"
 
+  // Optional permission gateways.
+  compileOnly "net.luckperms:api:5.4"
+  modCompileOnly "me.lucko:fabric-permissions-api:0.3.1"
+
   // Bundle Hikari inside the mod jar.
   include(implementation("com.zaxxer:HikariCP:5.1.0"))
 

--- a/src/main/java/dev/mincore/commands/TimezoneCommand.java
+++ b/src/main/java/dev/mincore/commands/TimezoneCommand.java
@@ -77,11 +77,7 @@ public final class TimezoneCommand {
     String sample = TimeDisplay.formatTime(Instant.now(), pref);
     Text header =
         Text.translatable(
-            "mincore.cmd.tz.help",
-            pref.zone().getId(),
-            offset,
-            pref.clock().description(),
-            sample);
+            "mincore.cmd.tz.help", pref.zone().getId(), offset, pref.clock().description(), sample);
     src.sendFeedback(() -> header, false);
     return 1;
   }
@@ -138,8 +134,7 @@ public final class TimezoneCommand {
       String sample = TimeDisplay.formatTime(Instant.now(), pref);
       String label = TimeDisplay.offsetLabel(pref.zone());
       Text msg =
-          Text.translatable(
-              "mincore.cmd.tz.clock.ok", pref.clock().description(), sample, label);
+          Text.translatable("mincore.cmd.tz.clock.ok", pref.clock().description(), sample, label);
       src.sendFeedback(() -> msg, false);
       return 1;
     } catch (IllegalArgumentException e) {

--- a/src/main/java/dev/mincore/perms/Perms.java
+++ b/src/main/java/dev/mincore/perms/Perms.java
@@ -1,0 +1,212 @@
+/* MinCore © 2025 — MIT */
+package dev.mincore.perms;
+
+import com.mojang.authlib.GameProfile;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.util.Tristate;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.UserCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Permission helper that prefers LuckPerms, then Fabric Permissions API, then vanilla operator
+ * levels.
+ *
+ * <p>This API is intentionally slim and stable so add-ons can depend on it without pulling in
+ * optional dependencies themselves. Callers should run permission checks on the server thread when
+ * a LuckPerms lookup is required so user data is already cached.
+ */
+public final class Perms {
+  private static final Logger LOG = LoggerFactory.getLogger("mincore");
+  private static final boolean LUCKPERMS_PRESENT =
+      isClassPresent("net.luckperms.api.LuckPermsProvider");
+  private static final boolean FABRIC_PERMISSIONS_PRESENT =
+      isClassPresent("me.lucko.fabric.api.permissions.v0.Permissions");
+  private static final AtomicBoolean LUCKPERMS_LOGGED = new AtomicBoolean();
+  private static final AtomicBoolean FABRIC_LOGGED = new AtomicBoolean();
+
+  private Perms() {}
+
+  /**
+   * Checks whether {@code player} has {@code node} according to LuckPerms, the Fabric Permissions
+   * API, or a vanilla operator level fallback.
+   *
+   * @param player online player to check. Call on the server thread.
+   * @param node permission node to evaluate
+   * @param opLevelFallback required vanilla op level if no permission plugins are present
+   * @return true if the player has the node or sufficient op level
+   */
+  public static boolean check(ServerPlayerEntity player, String node, int opLevelFallback) {
+    Objects.requireNonNull(player, "player");
+    Objects.requireNonNull(node, "node");
+    return check(PlayerAccess.of(player), node, opLevelFallback);
+  }
+
+  /**
+   * Checks permissions for the given {@code uuid}.
+   *
+   * <p>If the player is online the Fabric Permissions API and vanilla fallbacks behave identically
+   * to {@link #check(ServerPlayerEntity, String, int)}. When offline, the check falls back to the
+   * stored operator level if available.
+   *
+   * @param server active Minecraft server
+   * @param uuid player UUID
+   * @param node permission node to evaluate
+   * @param opLevelFallback required vanilla op level if no permission plugins are present
+   * @return true if the player has the node or sufficient op level
+   */
+  public static boolean checkUUID(
+      MinecraftServer server, UUID uuid, String node, int opLevelFallback) {
+    Objects.requireNonNull(server, "server");
+    Objects.requireNonNull(uuid, "uuid");
+    Objects.requireNonNull(node, "node");
+    return check(ServerAccess.of(server), uuid, node, opLevelFallback);
+  }
+
+  private static Boolean checkLuckPerms(UUID uuid, String node) {
+    if (!LUCKPERMS_PRESENT) {
+      return null;
+    }
+    try {
+      LuckPerms luckPerms = LuckPermsProvider.get();
+      if (luckPerms == null) {
+        return null;
+      }
+      User user = luckPerms.getUserManager().getUser(uuid);
+      if (user == null) {
+        return null;
+      }
+      Tristate result = user.getCachedData().getPermissionData().checkPermission(node);
+      return result == Tristate.UNDEFINED ? null : result.asBoolean();
+    } catch (IllegalStateException | NoClassDefFoundError error) {
+      if (LUCKPERMS_LOGGED.compareAndSet(false, true)) {
+        LOG.debug("LuckPerms API unavailable when checking permissions", error);
+      }
+      return null;
+    }
+  }
+
+  private static boolean isClassPresent(String className) {
+    try {
+      Class.forName(className, false, Perms.class.getClassLoader());
+      return true;
+    } catch (ClassNotFoundException ignored) {
+      return false;
+    }
+  }
+
+  static boolean check(PlayerAccess access, String node, int opLevelFallback) {
+    Boolean lpResult = checkLuckPerms(access.uuid(), node);
+    if (lpResult != null) {
+      return lpResult;
+    }
+
+    ServerPlayerEntity entity = access.asEntity();
+    if (entity != null && FABRIC_PERMISSIONS_PRESENT) {
+      try {
+        return me.lucko.fabric.api.permissions.v0.Permissions.check(entity, node, opLevelFallback);
+      } catch (NoClassDefFoundError error) {
+        if (FABRIC_LOGGED.compareAndSet(false, true)) {
+          LOG.debug("Fabric Permissions API present at compile-time but missing at runtime", error);
+        }
+      }
+    }
+
+    return access.hasPermissionLevel(opLevelFallback);
+  }
+
+  static boolean check(ServerAccess access, UUID uuid, String node, int opLevelFallback) {
+    Boolean lpResult = checkLuckPerms(uuid, node);
+    if (lpResult != null) {
+      return lpResult;
+    }
+
+    ServerPlayerEntity online = access.onlinePlayer(uuid);
+    if (online != null && FABRIC_PERMISSIONS_PRESENT) {
+      try {
+        return me.lucko.fabric.api.permissions.v0.Permissions.check(online, node, opLevelFallback);
+      } catch (NoClassDefFoundError error) {
+        if (FABRIC_LOGGED.compareAndSet(false, true)) {
+          LOG.debug("Fabric Permissions API present at compile-time but missing at runtime", error);
+        }
+      }
+    }
+
+    return access.hasPermissionLevel(uuid, opLevelFallback);
+  }
+
+  interface PlayerAccess {
+    UUID uuid();
+
+    ServerPlayerEntity asEntity();
+
+    boolean hasPermissionLevel(int opLevel);
+
+    static PlayerAccess of(ServerPlayerEntity player) {
+      return new PlayerAccess() {
+        @Override
+        public UUID uuid() {
+          return player.getUuid();
+        }
+
+        @Override
+        public ServerPlayerEntity asEntity() {
+          return player;
+        }
+
+        @Override
+        public boolean hasPermissionLevel(int opLevel) {
+          return player.hasPermissionLevel(opLevel);
+        }
+      };
+    }
+  }
+
+  interface ServerAccess {
+    ServerPlayerEntity onlinePlayer(UUID uuid);
+
+    boolean hasPermissionLevel(UUID uuid, int opLevel);
+
+    static ServerAccess of(MinecraftServer server) {
+      return new ServerAccess() {
+        @Override
+        public ServerPlayerEntity onlinePlayer(UUID uuid) {
+          PlayerManager manager = server.getPlayerManager();
+          return manager != null ? manager.getPlayer(uuid) : null;
+        }
+
+        @Override
+        public boolean hasPermissionLevel(UUID uuid, int opLevel) {
+          if (opLevel <= 0) {
+            return true;
+          }
+
+          PlayerManager manager = server.getPlayerManager();
+          if (manager == null) {
+            return false;
+          }
+
+          ServerPlayerEntity online = manager.getPlayer(uuid);
+          if (online != null) {
+            return online.hasPermissionLevel(opLevel);
+          }
+
+          UserCache cache = server.getUserCache();
+          GameProfile profile = cache != null ? cache.getByUuid(uuid).orElse(null) : null;
+          if (profile == null) {
+            return false;
+          }
+          return server.getPermissionLevel(profile) >= opLevel;
+        }
+      };
+    }
+  }
+}

--- a/src/main/java/dev/mincore/util/ClockFormat.java
+++ b/src/main/java/dev/mincore/util/ClockFormat.java
@@ -7,11 +7,11 @@ import java.util.Locale;
 /** Supported player-facing clock formats. */
 public enum ClockFormat {
   /** Twelve hour clock (2:20 PM). */
-  TWELVE_HOUR("12-hour", DateTimeFormatter.ofPattern("h:mm a"),
-      DateTimeFormatter.ofPattern("h:mm:ss a")),
+  TWELVE_HOUR(
+      "12-hour", DateTimeFormatter.ofPattern("h:mm a"), DateTimeFormatter.ofPattern("h:mm:ss a")),
   /** Twenty four hour clock (14:20). */
-  TWENTY_FOUR_HOUR("24-hour", DateTimeFormatter.ofPattern("HH:mm"),
-      DateTimeFormatter.ofPattern("HH:mm:ss"));
+  TWENTY_FOUR_HOUR(
+      "24-hour", DateTimeFormatter.ofPattern("HH:mm"), DateTimeFormatter.ofPattern("HH:mm:ss"));
 
   private final String description;
   private final DateTimeFormatter shortFormatter;
@@ -46,12 +46,10 @@ public enum ClockFormat {
     }
     String normalized = raw.trim().toLowerCase(Locale.ROOT);
     return switch (normalized) {
-      case "12", "12h", "12hr", "twelve", "twelve_hour", "12-hour", "twelve-hour" ->
-          TWELVE_HOUR;
+      case "12", "12h", "12hr", "twelve", "twelve_hour", "12-hour", "twelve-hour" -> TWELVE_HOUR;
       case "24", "24h", "24hr", "twentyfour", "twenty_four", "24-hour", "twenty-four" ->
           TWENTY_FOUR_HOUR;
       default -> throw new IllegalArgumentException("unknown clock format: " + raw);
     };
   }
 }
-

--- a/src/main/java/dev/mincore/util/TimeDisplay.java
+++ b/src/main/java/dev/mincore/util/TimeDisplay.java
@@ -82,4 +82,3 @@ public final class TimeDisplay {
     return shortName + " (" + offset + ")";
   }
 }
-

--- a/src/main/java/dev/mincore/util/TimePreference.java
+++ b/src/main/java/dev/mincore/util/TimePreference.java
@@ -17,4 +17,3 @@ public record TimePreference(ZoneId zone, ClockFormat clock, String source, long
     }
   }
 }
-

--- a/src/main/java/dev/mincore/util/Timezones.java
+++ b/src/main/java/dev/mincore/util/Timezones.java
@@ -16,15 +16,16 @@ import net.minecraft.server.command.ServerCommandSource;
 /** Helper for resolving/storing timezone overrides. */
 public final class Timezones {
   private static final String ATTR_KEY = "mincore.tz";
-  private static final List<String> TWELVE_HOUR_PREFIXES = List.of(
-      "America/",
-      "Pacific/Honolulu",
-      "Pacific/Midway",
-      "Pacific/Pago_Pago",
-      "Pacific/Rarotonga",
-      "Atlantic/Bermuda",
-      "Atlantic/Stanley",
-      "Atlantic/Faeroe");
+  private static final List<String> TWELVE_HOUR_PREFIXES =
+      List.of(
+          "America/",
+          "Pacific/Honolulu",
+          "Pacific/Midway",
+          "Pacific/Pago_Pago",
+          "Pacific/Rarotonga",
+          "Atlantic/Bermuda",
+          "Atlantic/Stanley",
+          "Atlantic/Faeroe");
 
   private Timezones() {}
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,5 +14,9 @@
     "fabricloader": ">=0.14.0",
     "minecraft": ">=1.20.0",
     "fabric-api": "*"
+  },
+  "suggests": {
+    "luckperms": "*",
+    "fabric-permissions-api-v0": "*"
   }
 }

--- a/src/test/java/dev/mincore/perms/PermsTest.java
+++ b/src/test/java/dev/mincore/perms/PermsTest.java
@@ -1,0 +1,61 @@
+/* MinCore © 2025 — MIT */
+package dev.mincore.perms;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.mincore.perms.Perms.PlayerAccess;
+import dev.mincore.perms.Perms.ServerAccess;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link Perms}. */
+final class PermsTest {
+  @Test
+  void classLoads() {
+    assertDoesNotThrow(() -> Class.forName("dev.mincore.perms.Perms"));
+  }
+
+  @Test
+  void fallsBackToOpLevelWhenNoIntegrationsPresent() {
+    UUID uuid = UUID.randomUUID();
+    PlayerAccess stub =
+        new PlayerAccess() {
+          @Override
+          public UUID uuid() {
+            return uuid;
+          }
+
+          @Override
+          public net.minecraft.server.network.ServerPlayerEntity asEntity() {
+            return null;
+          }
+
+          @Override
+          public boolean hasPermissionLevel(int opLevel) {
+            return opLevel <= 4;
+          }
+        };
+
+    assertTrue(Perms.check(stub, "mincore.test", 4));
+  }
+
+  @Test
+  void uuidCheckUsesOpLevelFallbackWhenOffline() {
+    UUID uuid = UUID.randomUUID();
+    ServerAccess server =
+        new ServerAccess() {
+          @Override
+          public net.minecraft.server.network.ServerPlayerEntity onlinePlayer(UUID ignored) {
+            return null;
+          }
+
+          @Override
+          public boolean hasPermissionLevel(UUID ignored, int opLevel) {
+            return opLevel <= 4;
+          }
+        };
+
+    assertTrue(Perms.check(server, uuid, "mincore.test", 4));
+  }
+}


### PR DESCRIPTION
## Summary
- add `dev.mincore.perms.Perms` to centralize LuckPerms, Fabric Permissions API, and vanilla operator fallback checks
- expose lightweight server/player adapters so add-ons can call `Perms.check(...)` from commands and document the gateway across the spec and developer guide
- note optional permission integrations in build metadata, Gradle, and README while keeping existing formatting consistent

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d5ba9fcb0c8333bddedcd50c57093e