### PR TITLE
Mark HolarkiMod singletons as volatile

### DIFF
--- a/src/main/java/dev/holarki/HolarkiMod.java
+++ b/src/main/java/dev/holarki/HolarkiMod.java
@@ -46,8 +46,8 @@ public final class HolarkiMod implements ModInitializer {
   public static final String MOD_ID = "holarki";
 
   private static final Logger LOG = LoggerFactory.getLogger(MOD_ID);
-  private static Config CONFIG;
-  private static ModuleManager MODULES;
+  private static volatile Config CONFIG;
+  private static volatile ModuleManager MODULES;
   private static ModuleManagerFactory moduleManagerFactory = ModuleManager::new;
 
   /** Public no-arg constructor for Fabric. */


### PR DESCRIPTION
## Summary
- mark the HolarkiMod CONFIG and MODULES singletons as volatile to ensure safe publication to other threads

## Testing
- gradle compileJava

------
https://chatgpt.com/codex/tasks/task_e_690404ba9d60833394b47769b47e04ef