### PR TITLE
feat: evict idle rate limiter buckets

### DIFF
--- a/src/main/java/dev/holarki/util/TokenBucketRateLimiter.java
+++ b/src/main/java/dev/holarki/util/TokenBucketRateLimiter.java
@@ -1,8 +1,12 @@
 /* Holarki © 2025 Holarki Devs — MIT */
 package dev.holarki.util;
 
+import java.time.Duration;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 
 /**
  * In-memory, thread-safe token bucket rate limiter.
@@ -14,6 +18,9 @@ import java.util.concurrent.ConcurrentHashMap;
  *   <li><strong>refillPerSec</strong>: tokens added per second (fractional allowed)
  * </ul>
  *
+ * <p>Idle buckets that remain completely full for {@code 5 minutes} are evicted automatically.
+ * This keeps the limiter's memory usage bounded even if new keys stop using their buckets.
+ *
  * <p>Call {@link #tryAcquire(String)} to consume one token. If a token is available, the call
  * succeeds and one token is removed; otherwise it fails. The limiter uses {@link System#nanoTime()}
  * internally to avoid issues when the system clock jumps.
@@ -21,17 +28,26 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class TokenBucketRateLimiter {
   private static final class Bucket {
     double tokens;
-    long lastNanos;
+    long lastRefillNanos;
+    long lastUsedNanos;
 
-    Bucket(double tokens, long lastNanos) {
+    Bucket(double tokens, long nowNanos) {
       this.tokens = tokens;
-      this.lastNanos = lastNanos;
+      this.lastRefillNanos = nowNanos;
+      this.lastUsedNanos = nowNanos;
     }
   }
 
   private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
   private final double capacity;
   private final double refillPerSec;
+  private final long bucketTtlNanos;
+  private final long cleanupIntervalNanos;
+  private final LongSupplier nanoTimeSource;
+  private final AtomicLong nextCleanupNanos;
+
+  private static final double FULL_EPSILON = 1e-9;
+  private static final Duration DEFAULT_BUCKET_TTL = Duration.ofMinutes(5);
 
   /**
    * Creates a token bucket limiter.
@@ -40,8 +56,35 @@ public final class TokenBucketRateLimiter {
    * @param refillPerSec tokens added per second (must be {@code > 0}; fractional allowed)
    */
   public TokenBucketRateLimiter(int capacity, double refillPerSec) {
+    this(capacity, refillPerSec, DEFAULT_BUCKET_TTL, System::nanoTime);
+  }
+
+  /**
+   * Creates a token bucket limiter with a custom idle eviction policy.
+   *
+   * @param capacity maximum number of tokens a bucket can hold (rounded up to at least {@code 1})
+   * @param refillPerSec tokens added per second (must be {@code > 0}; fractional allowed)
+   * @param bucketTtl how long an untouched, completely refilled bucket is retained before eviction
+   */
+  public TokenBucketRateLimiter(int capacity, double refillPerSec, Duration bucketTtl) {
+    this(capacity, refillPerSec, bucketTtl, System::nanoTime);
+  }
+
+  TokenBucketRateLimiter(
+      int capacity,
+      double refillPerSec,
+      Duration bucketTtl,
+      LongSupplier nanoTimeSource) {
+    Objects.requireNonNull(bucketTtl, "bucketTtl");
+    this.nanoTimeSource = Objects.requireNonNull(nanoTimeSource, "nanoTimeSource");
     this.capacity = Math.max(1, capacity);
     this.refillPerSec = Math.max(0.0001, refillPerSec);
+    this.bucketTtlNanos = Math.max(0L, bucketTtl.toNanos());
+    this.cleanupIntervalNanos = bucketTtlNanos;
+    long initialNow = this.nanoTimeSource.getAsLong();
+    long nextCleanup =
+        cleanupIntervalNanos == 0 ? Long.MAX_VALUE : initialNow + cleanupIntervalNanos;
+    this.nextCleanupNanos = new AtomicLong(nextCleanup);
   }
 
   /**
@@ -54,20 +97,56 @@ public final class TokenBucketRateLimiter {
    * @return {@code true} if a token was available and consumed; {@code false} otherwise
    */
   public boolean tryAcquire(String key) {
-    long nowNanos = System.nanoTime();
+    long nowNanos = nanoTimeSource.getAsLong();
+    maybeCleanup(nowNanos);
     Bucket b = buckets.computeIfAbsent(key, k -> new Bucket(capacity, nowNanos));
     synchronized (b) {
-      long delta = nowNanos - b.lastNanos;
-      if (delta > 0L) {
-        double elapsedSeconds = delta / 1_000_000_000.0d;
-        b.tokens = Math.min(capacity, b.tokens + elapsedSeconds * refillPerSec);
-        b.lastNanos = nowNanos;
-      }
+      refillBucket(b, nowNanos);
       if (b.tokens >= 1.0) {
         b.tokens -= 1.0;
+        b.lastUsedNanos = nowNanos;
         return true;
       }
       return false;
     }
+  }
+
+  int bucketCount() {
+    return buckets.size();
+  }
+
+  private void refillBucket(Bucket bucket, long nowNanos) {
+    long delta = nowNanos - bucket.lastRefillNanos;
+    if (delta > 0L) {
+      double elapsedSeconds = delta / 1_000_000_000.0d;
+      bucket.tokens = Math.min(capacity, bucket.tokens + elapsedSeconds * refillPerSec);
+      bucket.lastRefillNanos = nowNanos;
+    }
+  }
+
+  private void maybeCleanup(long nowNanos) {
+    if (bucketTtlNanos == 0 || cleanupIntervalNanos == 0) {
+      return;
+    }
+    long next = nextCleanupNanos.get();
+    if (nowNanos < next) {
+      return;
+    }
+    if (!nextCleanupNanos.compareAndSet(next, nowNanos + cleanupIntervalNanos)) {
+      return;
+    }
+    buckets.entrySet()
+        .removeIf(
+            entry -> {
+              Bucket bucket = entry.getValue();
+              synchronized (bucket) {
+                refillBucket(bucket, nowNanos);
+                if (bucket.tokens >= capacity - FULL_EPSILON) {
+                  long idleNanos = nowNanos - bucket.lastUsedNanos;
+                  return idleNanos >= bucketTtlNanos;
+                }
+              }
+              return false;
+            });
   }
 }

--- a/src/test/java/dev/holarki/util/TokenBucketRateLimiterTest.java
+++ b/src/test/java/dev/holarki/util/TokenBucketRateLimiterTest.java
@@ -1,0 +1,61 @@
+/* Holarki © 2025 Holarki Devs — MIT */
+package dev.holarki.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.function.LongSupplier;
+import org.junit.jupiter.api.Test;
+
+class TokenBucketRateLimiterTest {
+
+  @Test
+  void cleanupEvictsIdleFullBuckets() {
+    FakeTicker ticker = new FakeTicker();
+    Duration ttl = Duration.ofSeconds(5);
+    TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(2, 1.0, ttl, ticker);
+
+    assertTrue(limiter.tryAcquire("player"));
+    assertEquals(1, limiter.bucketCount());
+
+    ticker.advance(Duration.ofSeconds(1));
+    ticker.advance(ttl.plusSeconds(1));
+
+    assertTrue(limiter.tryAcquire("other"));
+    assertEquals(1, limiter.bucketCount(), "Idle bucket should be evicted during cleanup");
+
+    assertTrue(limiter.tryAcquire("player"));
+    assertEquals(2, limiter.bucketCount());
+  }
+
+  @Test
+  void evictionDoesNotGrantExtraTokens() {
+    FakeTicker ticker = new FakeTicker();
+    Duration ttl = Duration.ofSeconds(3);
+    TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(1, 1.0, ttl, ticker);
+
+    assertTrue(limiter.tryAcquire("player"));
+    assertFalse(limiter.tryAcquire("player"));
+
+    ticker.advance(Duration.ofSeconds(1));
+    ticker.advance(ttl.plusSeconds(1));
+
+    assertTrue(limiter.tryAcquire("player"));
+    assertFalse(limiter.tryAcquire("player"));
+  }
+
+  private static final class FakeTicker implements LongSupplier {
+    private long now;
+
+    @Override
+    public long getAsLong() {
+      return now;
+    }
+
+    void advance(Duration duration) {
+      now += duration.toNanos();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- track last-used timestamps per token bucket and expose a configurable idle TTL
- evict idle, fully refilled buckets during lightweight periodic cleanup from tryAcquire
- add unit tests that verify idle buckets are removed and do not regain extra tokens

## Testing
- not run (gradle wrapper is not available in the repository)

------
https://chatgpt.com/codex/tasks/task_e_690406d8947c8333880d424339625f22